### PR TITLE
feat: Include API's from Zendesk to manage zis integration

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -552,4 +552,46 @@ describe("ZendeskService", () => {
             });
         });
     });
+
+    describe("ZisIntegration", () => {
+        const zisIntegration = {
+            name: "Test Integration",
+            description: "Test Description",
+            jwt_public_key: "public_key",
+            zendesk_oauth_client: {
+                id: 1,
+                secret: "secret",
+                identifier: "identifier"
+            }
+        };
+
+        it("should return the Zis integration", async () => {
+            requestMock.mockResolvedValueOnce({ integrations: [zisIntegration] });
+
+            const result = await service.fetchZisIntegrations();
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `api/services/zis/registry/integrations`,
+                method: "GET",
+                contentType: "application/json"
+            });
+            expect(result).toEqual([zisIntegration]);
+        });
+
+        it("should create a new Zis integration", async () => {
+            requestMock.mockResolvedValueOnce(zisIntegration);
+
+            const result = await service.createZisIntegration(zisIntegration.name, zisIntegration.description);
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/services/zis/registry/${zisIntegration.name}`,
+                method: "POST",
+                contentType: "application/json",
+                data: JSON.stringify({
+                    description: zisIntegration.description
+                })
+            });
+            expect(result).toEqual(zisIntegration);
+        });
+    });
 });

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -1,0 +1,16 @@
+interface IZendeskOaithClient {
+    id: number;
+    secret: string;
+    identifier: string;
+}
+
+export interface IZisIntegration {
+    name: string;
+    description: string;
+    jwt_public_key: string;
+    zendesk_oauth_client: IZendeskOaithClient;
+}
+
+export interface IZisIntegrationResponse {
+    integrations: IZisIntegration[];
+}

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -27,6 +27,7 @@ import {
     IMessage,
     IMessagesResults
 } from "@models/index";
+import { IZisIntegration, IZisIntegrationResponse } from "@models/zendesk-integration-services";
 import { convertContentMessageToHtml } from "@utils/convert-content-message-to-html";
 import { getFromClient } from "@utils/get-from-client";
 import { Client } from "@zendesk/sell-zaf-app-toolbox";
@@ -290,5 +291,38 @@ export class ZendeskApiService {
             fetchAllMessages,
             (response) => response.messages
         );
+    }
+
+    /**
+     * Fetch Zis integrations
+     *
+     * @returns {Promise<IZisIntegration[]>} List of Zis integrations
+     */
+    public async fetchZisIntegrations(): Promise<IZisIntegration[]> {
+        const { integrations } = await this.client.request<unknown, IZisIntegrationResponse>({
+            url: `api/services/zis/registry/integrations`,
+            method: "GET",
+            contentType: "application/json"
+        });
+
+        return integrations;
+    }
+
+    /**
+     * Create Zis Integrations
+     *
+     * @param {string} name Name of the Zis integration
+     * @param {string} description Description of the Zis integration
+     * @returns {Promise<IZisIntegration>} List of Zis integrations
+     */
+    public async createZisIntegration(name: string, description: string): Promise<IZisIntegration> {
+        return await this.client.request<unknown, IZisIntegration>({
+            url: `/api/services/zis/registry/${name}`,
+            method: "POST",
+            contentType: "application/json",
+            data: JSON.stringify({
+                description
+            })
+        });
     }
 }


### PR DESCRIPTION
## Description

This PR introduces support for Zendesk Integration Services (ZIS) within the Zendesk API service. It adds new interfaces to define the structure of ZIS integration objects and responses. Two new methods are implemented in the `ZendeskApiService` class: one to fetch the list of ZIS integrations and another to create a new ZIS integration. Corresponding unit tests are added to validate the new functionality.

## How to manually test

1. Run existing test suite to verify no regressions are introduced.
2. Execute the new tests in `__tests__/services/zendesk-api-service.spec.ts` to verify:
   - Fetching ZIS integrations calls the correct API endpoint and returns expected results.
   - Creating a ZIS integration sends the appropriate data and receives the correct response.
3. Optionally, manually call the new methods `fetchZisIntegrations()` and `createZisIntegration(name, description)` from the `ZendeskApiService` class in an integration environment connected to the actual Zendesk API.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?