### PR TITLE
feat: Add possibility to deal with Zis Job spec inside the zendesk ap…

### DIFF
--- a/src/models/custom-objects.ts
+++ b/src/models/custom-objects.ts
@@ -110,7 +110,7 @@ export enum ListCutomObjectRecordsSortingOptions {
     MINUS_UPDATED_AT = "-updated_at"
 }
 
-export interface IListCustomObjectRecordsFilter {
+export interface IListFilter {
     filter?: {
         /**
          * Comma separated list of external ids of records
@@ -141,7 +141,7 @@ export interface IListCustomObjectRecordsFilter {
     sort?: ListCutomObjectRecordsSortingOptions;
 }
 
-export interface ISearchCustomObjectRecordsFilter extends IListCustomObjectRecordsFilter {
+export interface ISearchCustomObjectRecordsFilter extends IListFilter {
     query: string;
 }
 

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -14,3 +14,22 @@ export interface IZisIntegration {
 export interface IZisIntegrationResponse {
     integrations: IZisIntegration[];
 }
+
+export interface IZisJobspec {
+    description: string;
+    event_source: string;
+    event_type: string;
+    flow_name: string;
+    installed: boolean;
+    integration: string;
+    name: string;
+    uuid: string;
+}
+export interface IZisJobspecsResponse {
+    job_specs: IZisJobspec[];
+    meta: {
+        after: string;
+        before: string;
+        has_more: boolean;
+    };
+}

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -7,7 +7,7 @@ import {
     IGetCustomObjectRecordsResponse,
     IListCustomObjectsResponse,
     ICreateCustomObjectRecordBody,
-    IListCustomObjectRecordsFilter,
+    IListFilter,
     IListCustomObjectRecordsResponse,
     ICustomObjectRecord,
     ListCutomObjectRecordsSortingOptions,
@@ -122,7 +122,7 @@ export class CustomObjectService {
      */
     public async listCustomObjectRecords<T extends ICustomObjectRecordField>(
         key: string,
-        data?: IListCustomObjectRecordsFilter
+        data?: IListFilter
     ): Promise<ICustomObjectRecord<T>[]> {
         const { custom_object_records } = await this.client.request<any, IListCustomObjectRecordsResponse<T>>({
             url: `/api/v2/custom_objects/${key}/records`,
@@ -143,7 +143,7 @@ export class CustomObjectService {
     ): Promise<ICustomObjectRecord<T>[]> {
         return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records`, {
             sort: sortOptions?.sort
-        } as IListCustomObjectRecordsFilter);
+        } as IListFilter);
     }
 
     /**
@@ -243,7 +243,7 @@ export class CustomObjectService {
      */
     private async fetchAllPaginatedRecords<T extends ICustomObjectRecordField>(
         url: string,
-        initialData: IListCustomObjectRecordsFilter
+        initialData: IListFilter
     ): Promise<ICustomObjectRecord<T>[]> {
         let hasMore = true;
         let data = initialData;
@@ -270,7 +270,7 @@ export class CustomObjectService {
                               sort: initialData.sort
                           }
                         : undefined)
-                } as IListCustomObjectRecordsFilter;
+                } as IListFilter;
             }
         } while (hasMore);
 


### PR DESCRIPTION
## Description

This PR adds support for managing Zendesk Integration Services (ZIS) job specifications in the Zendesk API service. It introduces new methods to:

- Fetch paginated ZIS job specs for an integration, handling multiple pages when `has_more` is true.
- Create (install) a ZIS job spec by name.
- Delete a ZIS job spec by name.

Additionally, new TypeScript interfaces representing ZIS job specs and their paginated response have been added in the `zendesk-integration-services` model.

The change also updates existing code to rename some interfaces for clarity (`IListCustomObjectRecordsFilter` to `IListFilter`), and adds comprehensive unit tests for the new ZIS job specs functionality covering fetching (including pagination), creation, and deletion.

## How to manually test

1. Run the unit tests located in `__tests__/services/zendesk-api-service.spec.ts` to verify the new ZIS job specs methods.
2. Use the `ZendeskApiService` class in a development or staging environment to:
   - Fetch job specs for a given integration name and verify multiple pages are handled.
   - Create a job spec by passing its name to `createZisJobSpec`.
   - Delete a job spec by passing its name to `deleteZisJobSpec`.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?