### PR TITLE
feat: Add support for Zis Connection, Zis Token and zis webhook

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -697,4 +697,64 @@ describe("ZendeskService", () => {
             expect(requestMock).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("createAccessToken", () => {
+        it("should create an access token with the correct data", async () => {
+            await service.createZendeskAccessToken(102, ["read", "write"]);
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: "/api/v2/oauth/tokens.json",
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify({
+                    token: {
+                        client_id: 102,
+                        scopes: ["read", "write"]
+                    }
+                })
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("createZisConnection", () => {
+        it("should create an access token with the correct data", async () => {
+            await service.createZisConnection("integrationName", "token", "connectionName", "zendesk.com");
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: "/api/services/zis/integrations/integrationName/connections/bearer_token",
+                type: "POST",
+                contentType: "application/json",
+                headers: {
+                    Authorization: "Bearer token"
+                },
+                data: JSON.stringify({
+                    name: "connectionName",
+                    token: "token",
+                    allowed_domain: "zendesk.com"
+                })
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("createZisInboundWebhook", () => {
+        it("should create an access token with the correct data", async () => {
+            await service.createZisInboundWebhook("integrationName", "token", "source", "eventType");
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: "/api/services/zis/inbound_webhooks/generic/integrationName",
+                type: "POST",
+                contentType: "application/json",
+                headers: {
+                    Authorization: "Bearer token"
+                },
+                data: JSON.stringify({
+                    source_system: "source",
+                    event_type: "eventType"
+                })
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.4.3",
+    "version": "0.5.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/zendesk-api.ts
+++ b/src/models/zendesk-api.ts
@@ -147,3 +147,22 @@ export interface IMessage {
 export interface IMessagesResults extends IZendeskResponse {
     messages: IMessage[];
 }
+
+export interface ICreateAccessTokenResponseToken {
+    url: string;
+    id: number;
+    user_id: number;
+    client_id: number;
+    token: string;
+    refresh_token: string | null;
+    created_at: string;
+    expires_at: string | null;
+    used_at: string | null;
+    scopes: string[];
+    refresh_token_expires_at: string | null;
+    full_token: string;
+}
+
+export interface ICreateAccessTokenResponse {
+    token: ICreateAccessTokenResponseToken;
+}

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -33,3 +33,27 @@ export interface IZisJobspecsResponse {
         has_more: boolean;
     };
 }
+
+export interface IBearerTokenResponse {
+    name: string;
+    token: string;
+    allowed_domain: string;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface ICreateConnectionResponse {
+    bearer_token: IBearerTokenResponse;
+}
+
+export interface ICreateInboundWebhookResponse {
+    id: string;
+    uuid: string;
+    zendesk_account_id: number;
+    path: string;
+    integration: string;
+    source_system: string;
+    event_type: string;
+    username: string;
+    password: string;
+}


### PR DESCRIPTION
## Description

This PR introduces new features to the Zendesk API service integration:

- Adds the ability to create OAuth access tokens via `createZendeskAccessToken` method.
- Implements methods to create ZIS (Zendesk Integration Services) connections (`createZisConnection`) and inbound webhooks (`createZisInboundWebhook`).
- Adds corresponding TypeScript models for the new API responses.
- Includes comprehensive tests for these new service methods to verify correct request payloads.

These enhancements enable programmatic creation and management of access tokens, connections, and webhooks for Zendesk integrations within the service.

## How to manually test

1. Use the test suite to verify new coverage:
   ```bash
   npm run test __tests__/services/zendesk-api-service.spec.ts
   ```
2. Alternatively, instantiate `ZendeskApiService` and call:
   - `createZendeskAccessToken(clientId, scopes)`
   - `createZisConnection(integrationName, token, connectionName, allowedDomain)`
   - `createZisInboundWebhook(integrationName, token, sourceSystem, eventType)`
3. Confirm that the requests are correctly formatted and the responses match expected interface structures.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?