### PR TITLE
feat: Add capabilities for Zendesk API service to upload bundle to a zis integration

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -757,4 +757,20 @@ describe("ZendeskService", () => {
             expect(requestMock).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("uploadZisBundle", () => {
+        it("should upload a Zis bundle with the correct data", async () => {
+            await service.uploadZisBundle("integrationName", {
+                name: "zis:bundle"
+            });
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: `/api/services/zis/registry/integrationName/bundles`,
+                method: "POST",
+                contentType: "application/json",
+                data: JSON.stringify({ name: "zis:bundle" })
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -481,4 +481,19 @@ export class ZendeskApiService {
             })
         });
     }
+
+    /**
+     * Fetches the ZIS integration by name.
+     *
+     * @param {string} integrationName - The name of the ZIS integration.
+     * @returns {Promise<void>} - The ZIS integration object.
+     **/
+    public async uploadZisBundle(integrationName: string, bundle: unknown): Promise<void> {
+        return await this.client.request({
+            url: `/api/services/zis/registry/${integrationName}/bundles`,
+            method: "POST",
+            contentType: "application/json",
+            data: JSON.stringify(bundle)
+        });
+    }
 }


### PR DESCRIPTION
## Description

This PR adds a new method `uploadZisBundle` to the `ZendeskApiService` that allows uploading a ZIS bundle to a specific integration. The method performs a POST request with the given bundle data to the appropriate ZIS registry endpoint.

Additionally, new tests were added in `__tests__/services/zendesk-api-service.spec.ts` to verify the behavior of the `uploadZisBundle` method, ensuring the request is made with the correct URL, method, content type, and data.

## How to manually test

1. Import `ZendeskApiService` and instantiate it.
2. Call the `uploadZisBundle` method with an integration name and a bundle object.
3. Verify that the HTTP request is sent to `/api/services/zis/registry/{integrationName}/bundles` using POST with JSON payload.
4. Run the test suite to confirm the new test cases pass.

## Include label

- Version: Minor

## Acceptation criteria

- [ ] Added the corrected label to my pull request
- [ ] Added/updated tests impacted by the change
- [ ] Documentation is up-to-date (README.md / INSTALL.md)
- [ ] Manually tested?