### PR TITLE
Update `ICustomObjectRecordField` to not only accept string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/custom-objects.ts
+++ b/src/models/custom-objects.ts
@@ -72,7 +72,8 @@ enum DELETEDStatusExtends {
 type ITemplateStatus = TemplateStatus | SMSStatusExtends | DELETEDStatusExtends;
 export const ITemplateStatus = { ...TemplateStatus, ...SMSStatusExtends, ...DELETEDStatusExtends };
 
-export type ICustomObjectRecordField = Record<string, string>;
+export type PossibleValueForCustomField = string | number | boolean;
+export type ICustomObjectRecordField = Record<string, PossibleValueForCustomField>;
 
 export interface ICustomObjectRecord<T extends ICustomObjectRecordField> {
     created_at: string;


### PR DESCRIPTION
## Description

This PR updates the type definition of the `ICustomObjectRecordField` in the custom objects model. Instead of restricting each record field value to only strings, it now allows a broader range of types including string, number, and boolean. This enhances type flexibility for custom object records.

## How to manually test

1. Check out the branch with this change.
2. In any code using `ICustomObjectRecordField`, try assigning values of types string, number, and boolean.
3. Confirm that type validation succeeds for all of these types.

## Include label

- Version: Patch

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?