### PR TITLE
chore(types): Update custom objects types with the update of data

### DIFF
--- a/src/models/custom-objects.ts
+++ b/src/models/custom-objects.ts
@@ -147,6 +147,8 @@ type ISearchFilterComparaison = Record<
     string,
     {
         "$eq"?: string | number | boolean;
+        "$gt"?: string | number | boolean;
+        "$contains"?: string | number | boolean;
     }
 >;
 export interface ISearchFilterCustomObjectRecords extends IPaginationAndSortCursor {


### PR DESCRIPTION
## Description

Added new comparison operators `$gt` (greater than) and `$contains` to the `ISearchFilterComparaison` type in the `custom-objects.ts` model to extend filtering capabilities.

## How to manually test

1. Use the updated `ISearchFilterComparaison` type within search filters.
2. Verify that filters using `$gt` and `$contains` are accepted and behave as expected in the application.

## Include label

- Version: Patch

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?