### PR TITLE
Filter is not saved when fetching records with different pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -348,14 +348,10 @@ export class CustomObjectService {
             hasMore = response.meta.has_more;
             if (hasMore) {
                 d = {
+                    ...initialData,
                     page: {
                         after: response.meta.after_cursor
-                    },
-                    ...(initialData.sort
-                        ? {
-                              sort: initialData.sort
-                          }
-                        : undefined)
+                    }
                 } as IListFilter;
             }
         } while (hasMore);


### PR DESCRIPTION
## Description

This PR improves the `CustomObjectService` by ensuring that when filtering custom object records with pagination, the original filter is correctly preserved and applied across all pages of results. The pagination data merges correctly with the initial filter without losing other filter or sort parameters.

Additionally, a new test is added to verify that the Zendesk API is called with the filter correctly and that the filter is consistently applied on subsequent paginated requests.

## How to manually test

1. Run the test suite, especially the `CustomObjectService` tests.
2. Confirm that the new test `should call Zendesk API with filter correctly and keep filter on threw pages` passes.
3. Optionally, call `filterRecords` method with filtering and pagination parameters and observe that the filter remains consistent throughout paginated API calls.

## Include label

- Version: Patch

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [ ] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?