### PR TITLE
Include external_id in the body for Custom object records ( Body already include the key )

### DIFF
--- a/__tests__/services/custom-objects.spec.ts
+++ b/__tests__/services/custom-objects.spec.ts
@@ -225,7 +225,8 @@ describe("CustomObjectService", () => {
                 name: "foo",
                 custom_object_fields: {
                     test: "true"
-                }
+                },
+                external_id: "12345"
             } as unknown as ICreateCustomObjectRecordBody<Record<string, string>>;
             await service.createCustomObjectRecord("foo", body);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.11.2",
+    "version": "0.11.3",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -177,10 +177,7 @@ export class CustomObjectService {
             type: "POST",
             contentType: CONTENT_TYPE,
             data: JSON.stringify({
-                custom_object_record: {
-                    name: body.name,
-                    custom_object_fields: body.custom_object_fields
-                }
+                custom_object_record: body
             })
         });
 


### PR DESCRIPTION
## Description

This PR updates the `CustomObjectService` to directly assign the entire `body` object to the `custom_object_record` field in the request payload, instead of manually specifying only `name` and `custom_object_fields`. This change allows additional properties like `external_id` to be included in the created custom object record. The test file is updated accordingly to include an `external_id` property in the custom object record creation payload.

## How to manually test

1. Run the updated test suite: `__tests__/services/custom-objects.spec.ts`
2. Verify that the custom object record creation includes the `external_id` property and that all tests pass.
3. Optionally, trigger the `createCustomObjectRecord` method with a payload containing extra fields like `external_id` and confirm these fields are correctly sent in the API request.

## Include label

- Version: Patch

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?