### PR TITLE
Adding possibility to count elements without fetching all element for custom object filters

### DIFF
--- a/__tests__/services/custom-objects.spec.ts
+++ b/__tests__/services/custom-objects.spec.ts
@@ -430,6 +430,39 @@ describe("CustomObjectService", () => {
             expect(requestMock).toHaveBeenCalledTimes(2);
         });
 
+        it("should return only first page of records if fetchAllPages is false", async () => {
+            const mockResponse = {
+                count: 300,
+                custom_object_records: [customObjectRecord],
+                meta: {
+                    has_more: true,
+                    after_cursor: "1"
+                }
+            };
+            requestMock.mockResolvedValueOnce(mockResponse);
+
+            const filter = {
+                filter: {
+                    "$and": [
+                        {
+                            "custom_object_fields.color": {
+                                "$eq": "Red"
+                            }
+                        }
+                    ]
+                }
+            };
+            const res = await service.filterRecords("foo", filter, false);
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: `/api/v2/custom_objects/foo/records/search`,
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify(filter)
+            });
+            expect(res).toStrictEqual(mockResponse);
+        });
+
         it("should keep sort threw all pages ", async () => {
             requestMock
                 .mockResolvedValueOnce({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.11.2",
+    "version": "0.12.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/custom-objects.ts
+++ b/src/models/custom-objects.ts
@@ -214,6 +214,7 @@ export interface IListCustomObjectFieldsResponse {
 }
 
 export interface IListCustomObjectRecordsResponse<T extends ICustomObjectRecordField> {
+    count: number;
     custom_object_records: ICustomObjectRecord<T>[];
     meta: IZendeskMeta;
 }

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -279,7 +279,7 @@ export class CustomObjectService {
     public async filterRecords<T extends ICustomObjectRecordField>(
         key: string,
         filter: ISearchFilterCustomObjectRecords,
-        fetchAllPages: true
+        fetchAllPages?: true
     ): Promise<ICustomObjectRecord<T>[]>;
     public async filterRecords<T extends ICustomObjectRecordField>(
         key: string,

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -278,9 +278,29 @@ export class CustomObjectService {
      */
     public async filterRecords<T extends ICustomObjectRecordField>(
         key: string,
-        filter: ISearchFilterCustomObjectRecords
-    ): Promise<ICustomObjectRecord<T>[]> {
-        return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records/search`, filter, "POST");
+        filter: ISearchFilterCustomObjectRecords,
+        fetchAllPages: true
+    ): Promise<ICustomObjectRecord<T>[]>;
+    public async filterRecords<T extends ICustomObjectRecordField>(
+        key: string,
+        filter: ISearchFilterCustomObjectRecords,
+        fetchAllPages: false
+    ): Promise<IListCustomObjectRecordsResponse<T>>;
+    public async filterRecords<T extends ICustomObjectRecordField>(
+        key: string,
+        filter: ISearchFilterCustomObjectRecords,
+        fetchAllPages = true
+    ): Promise<ICustomObjectRecord<T>[] | IListCustomObjectRecordsResponse<T>> {
+        if (fetchAllPages) {
+            return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records/search`, filter, "POST");
+        } else {
+            return this.client.request<any, IListCustomObjectRecordsResponse<T>>({
+                url: `/api/v2/custom_objects/${key}/records/search`,
+                type: "POST",
+                contentType: CONTENT_TYPE,
+                data: JSON.stringify(filter)
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

This PR updates the `CustomObjectService` by enhancing the `filterRecords` method to support fetching either all paginated records or only the first page of records based on a new optional `fetchAllPages` parameter. When `fetchAllPages` is `false`, the method returns response metadata along with the first page of records. Additionally, the interface `IListCustomObjectRecordsResponse` was updated to include a `count` property to reflect the total number of records in the response.

A new unit test was added to verify that when `fetchAllPages` is `false`, only the first page of records is returned with the correct API call and response structure.

## How to manually test

1. Install the updated package version locally or deploy the updated service.
2. Call the `filterRecords` method from `CustomObjectService` with `fetchAllPages` set to `false` and verify it returns only the first page of records with metadata.
3. Call the same method with `fetchAllPages` omitted or set to `true` and verify it fetches all pages of records.
4. Run the updated test suite to ensure all tests pass, including the new test case for partial fetch.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?