### PR TITLE
Implement method to set record based on external id

### DIFF
--- a/__tests__/services/custom-objects.spec.ts
+++ b/__tests__/services/custom-objects.spec.ts
@@ -263,6 +263,33 @@ describe("CustomObjectService", () => {
             });
         });
 
+        it("should call set by external id with the correct parameters", async () => {
+            requestMock.mockResolvedValueOnce({
+                "custom_object_record": customObjectRecord
+            });
+
+            const body = {
+                name: "foo",
+                custom_object_fields: {
+                    test: "false"
+                }
+            } as unknown as ICreateCustomObjectRecordBody<Record<string, string>>;
+            await service.setCustomObjectRecordByExternalId("foo", body, "external_id");
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/v2/custom_objects/foo/records?external_id=external_id`,
+                type: "PATCH",
+                contentType: "application/json",
+                data: JSON.stringify({
+                    custom_object_record: {
+                        name: body.name,
+                        custom_object_fields: body.custom_object_fields,
+                        external_id: "external_id"
+                    }
+                })
+            });
+        });
+
         it("should call delete with the correct key", async () => {
             requestMock.mockResolvedValueOnce({});
 

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -208,6 +208,31 @@ export class CustomObjectService {
     }
 
     /**
+     * Set custom object record by external ID for a custom objects
+     * More information: https://developer.zendesk.com/api-reference/custom-data/custom-objects/custom_object_records/#set-custom-object-record-by-external-id-or-name
+     */
+    public async setCustomObjectRecordByExternalId<T extends ICustomObjectRecordField>(
+        key: string,
+        body: ICreateCustomObjectRecordBody<T>,
+        externalId: string
+    ): Promise<ICustomObjectRecord<T>> {
+        const { custom_object_record } = await this.client.request<any, IGetCustomObjectRecordsResponse<T>>({
+            url: `/api/v2/custom_objects/${key}/records?external_id=${externalId}`,
+            type: "PATCH",
+            contentType: CONTENT_TYPE,
+            data: JSON.stringify({
+                custom_object_record: {
+                    name: body.name,
+                    custom_object_fields: body.custom_object_fields,
+                    external_id: externalId
+                }
+            })
+        });
+
+        return custom_object_record;
+    }
+
+    /**
      * Delete custom object record for a custom objects
      */
     public async deleteCustomObjectRecord(key: string, id: string): Promise<void> {


### PR DESCRIPTION
## Description

This PR introduces a new method `setCustomObjectRecordByExternalId` in the `CustomObjectService` to allow setting a custom object record by its external ID. This method sends a PATCH request to the API endpoint to update the record identified by the external ID.

Additionally, a corresponding unit test for this new method has been added in the `custom-objects.spec.ts` file to verify that the request is made with the correct parameters.

## How to manually test

1. Run the unit tests with your preferred test runner (e.g., `jest`) to verify the new test in `__tests__/services/custom-objects.spec.ts` passes.
2. Use the `setCustomObjectRecordByExternalId` method in your development environment with a valid custom object key, body, and external ID.
3. Confirm the API PATCH request is successfully sent and that the custom object record is updated accordingly.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?