### PR TITLE
chore: Implement Zaf Client type instead of relying on old package

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ Here is a TL;DR; version of the installation guide:
 5. Create a `.npmrc` file at the root of your repository and copy the following on it: `@zendesk:registry=https://npm.pkg.github.com`
 6. Execute the following command:
     ```shell
-    npm i @zendesk/zaf-toolbox --legacy-peer-deps
+    npm i @zendesk/zaf-toolbox
     ```
-    The `--legacy-peer-deps` is needed because of the `@zendesk/sell-zaf-app-toolbox` dependency of this package.
 
 For more information on package installing through GitHub packages,
 see "[Installing a package](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#installing-a-package)".

--- a/__tests__/services/custom-fields-service.spec.ts
+++ b/__tests__/services/custom-fields-service.spec.ts
@@ -1,6 +1,6 @@
 import { MissingCustomFields } from "@errors/missing-custom-fields";
 import { CustomFieldsService, ZendeskApiService } from "@services/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 const mockClient = {
     request: jest.fn(),
@@ -16,7 +16,7 @@ describe("CustomFieldsService", () => {
         const defaultIdentifiers: string[] = ["TicketFieldOrderCreatedAt"];
         const service = (fetchFromApi = true, identifiers: string[] = defaultIdentifiers): CustomFieldsService => {
             return new CustomFieldsService(
-                mockClient as unknown as Client,
+                mockClient as unknown as IClient,
                 ZendeskApiServiceMock as unknown as ZendeskApiService,
                 identifiers,
                 fetchFromApi

--- a/__tests__/services/custom-objects.spec.ts
+++ b/__tests__/services/custom-objects.spec.ts
@@ -6,7 +6,7 @@ import {
     IBulkJobBodyCreate
 } from "@models/custom-objects";
 import { CustomObjectService } from "@services/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 describe("CustomObjectService", () => {
     const requestMock = jest.fn();
@@ -15,7 +15,7 @@ describe("CustomObjectService", () => {
     const service = new CustomObjectService({
         request: requestMock,
         get: getMock
-    } as unknown as Client);
+    } as unknown as IClient);
 
     describe("CustomObject", () => {
         it("should call list with the correct parameters", async () => {

--- a/__tests__/services/sunshine-conversation-api-service.spec.ts
+++ b/__tests__/services/sunshine-conversation-api-service.spec.ts
@@ -48,7 +48,9 @@ describe("SunshineConversationApiService", () => {
         metadata: jest.fn(),
         context: jest.fn(),
         trigger: jest.fn(),
-        instance: jest.fn()
+        instance: jest.fn(),
+        has: jest.fn(),
+        off: jest.fn()
     };
     const sunshineConversationApiService = new SunshineConversationApiService(appSettings, client);
 

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "@models/index";
 import { UPDATE_USER_FIELD_MAX_USERS, ZendeskApiService } from "@services/zendesk-api-service";
 import { convertContentMessageToHtml } from "@utils/convert-content-message-to-html";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 describe("ZendeskService", () => {
     const ticketId = 123;
@@ -20,7 +20,7 @@ describe("ZendeskService", () => {
     const service = new ZendeskApiService({
         request: requestMock,
         get: getMock
-    } as unknown as Client);
+    } as unknown as IClient);
 
     afterEach(() => {
         jest.clearAllMocks();
@@ -207,7 +207,9 @@ describe("ZendeskService", () => {
                 requestMock.mockResolvedValueOnce({ user: userSample });
                 const result = await service.getUser(123);
 
-                expect(requestMock).toHaveBeenCalledWith(`/api/v2/users/123`);
+                expect(requestMock).toHaveBeenCalledWith({
+                    url: `/api/v2/users/123`
+                });
                 expect(result).toBe(userSample);
             });
         });
@@ -220,9 +222,9 @@ describe("ZendeskService", () => {
 
                 const users = await service.searchUsers(searchQuery);
 
-                expect(requestMock).toHaveBeenCalledWith(
-                    `/api/v2/users/search?query=${encodeURIComponent(searchQuery)}`
-                );
+                expect(requestMock).toHaveBeenCalledWith({
+                    url: `/api/v2/users/search?query=${encodeURIComponent(searchQuery)}`
+                });
                 expect(users).toHaveLength(1);
                 expect(users[0]).toBe(userSample);
             });
@@ -235,11 +237,12 @@ describe("ZendeskService", () => {
                 const users = await service.searchUsers(searchQuery);
 
                 expect(requestMock).toHaveBeenCalledTimes(2);
-                expect(requestMock).toHaveBeenNthCalledWith(
-                    1,
-                    `/api/v2/users/search?query=${encodeURIComponent(searchQuery)}`
-                );
-                expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                expect(requestMock).toHaveBeenNthCalledWith(1, {
+                    url: `/api/v2/users/search?query=${encodeURIComponent(searchQuery)}`
+                });
+                expect(requestMock).toHaveBeenNthCalledWith(2, {
+                    url: "next_page"
+                });
                 expect(users).toHaveLength(1);
                 expect(users[0]).toBe(userSample);
             });
@@ -250,9 +253,9 @@ describe("ZendeskService", () => {
                 const users = await service.searchUsers(searchQuery, false);
 
                 expect(requestMock).toHaveBeenCalledTimes(1);
-                expect(requestMock).toHaveBeenCalledWith(
-                    `/api/v2/users/search?query=${encodeURIComponent(searchQuery)}`
-                );
+                expect(requestMock).toHaveBeenCalledWith({
+                    url: `/api/v2/users/search?query=${encodeURIComponent(searchQuery)}`
+                });
                 expect(users).toHaveLength(1);
                 expect(users[0]).toBe(userSample);
             });
@@ -264,7 +267,9 @@ describe("ZendeskService", () => {
 
                 const userFields = await service.getUserFields();
 
-                expect(requestMock).toHaveBeenCalledWith(`/api/v2/user_fields`);
+                expect(requestMock).toHaveBeenCalledWith({
+                    url: `/api/v2/user_fields`
+                });
                 expect(userFields).toHaveLength(1);
                 expect(userFields[0]).toBe(userFieldSample);
             });
@@ -277,8 +282,12 @@ describe("ZendeskService", () => {
                 const userFields = await service.getUserFields();
 
                 expect(requestMock).toHaveBeenCalledTimes(2);
-                expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/user_fields`);
-                expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                expect(requestMock).toHaveBeenNthCalledWith(1, {
+                    url: `/api/v2/user_fields`
+                });
+                expect(requestMock).toHaveBeenNthCalledWith(2, {
+                    url: "next_page"
+                });
                 expect(userFields).toHaveLength(1);
                 expect(userFields[0]).toBe(userFieldSample);
             });
@@ -289,7 +298,9 @@ describe("ZendeskService", () => {
                 const userFields = await service.getUserFields(false);
 
                 expect(requestMock).toHaveBeenCalledTimes(1);
-                expect(requestMock).toHaveBeenCalledWith(`/api/v2/user_fields`);
+                expect(requestMock).toHaveBeenCalledWith({
+                    url: `/api/v2/user_fields`
+                });
                 expect(userFields).toHaveLength(1);
                 expect(userFields[0]).toBe(userFieldSample);
             });
@@ -332,7 +343,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getTags();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/tags`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/tags`
+                    });
                     expect(result).toEqual(tags);
                 });
 
@@ -345,8 +358,12 @@ describe("ZendeskService", () => {
                     const result = await service.getTags();
 
                     expect(requestMock).toHaveBeenCalledTimes(2);
-                    expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/tags`);
-                    expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                    expect(requestMock).toHaveBeenNthCalledWith(1, {
+                        url: `/api/v2/tags`
+                    });
+                    expect(requestMock).toHaveBeenNthCalledWith(2, {
+                        url: "next_page"
+                    });
                     expect(result).toEqual(tags);
                 });
 
@@ -357,7 +374,9 @@ describe("ZendeskService", () => {
                     const result = await service.getTags(false);
 
                     expect(requestMock).toHaveBeenCalledTimes(1);
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/tags`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/tags`
+                    });
                     expect(result).toEqual(tags);
                 });
             });
@@ -369,7 +388,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getGroups();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/groups`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/groups`
+                    });
                     expect(result).toEqual(groups);
                 });
 
@@ -382,8 +403,12 @@ describe("ZendeskService", () => {
                     const result = await service.getGroups();
 
                     expect(requestMock).toHaveBeenCalledTimes(2);
-                    expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/groups`);
-                    expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                    expect(requestMock).toHaveBeenNthCalledWith(1, {
+                        url: `/api/v2/groups`
+                    });
+                    expect(requestMock).toHaveBeenNthCalledWith(2, {
+                        url: "next_page"
+                    });
                     expect(result).toEqual(groups);
                 });
 
@@ -394,7 +419,9 @@ describe("ZendeskService", () => {
                     const result = await service.getGroups(false);
 
                     expect(requestMock).toHaveBeenCalledTimes(1);
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/groups`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/groups`
+                    });
                     expect(result).toEqual(groups);
                 });
             });
@@ -406,7 +433,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getOrganizations();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/organizations`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/organizations`
+                    });
                     expect(result).toEqual(organizations);
                 });
 
@@ -419,8 +448,12 @@ describe("ZendeskService", () => {
                     const result = await service.getOrganizations();
 
                     expect(requestMock).toHaveBeenCalledTimes(2);
-                    expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/organizations`);
-                    expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                    expect(requestMock).toHaveBeenNthCalledWith(1, {
+                        url: `/api/v2/organizations`
+                    });
+                    expect(requestMock).toHaveBeenNthCalledWith(2, {
+                        url: "next_page"
+                    });
                     expect(result).toEqual(organizations);
                 });
 
@@ -431,7 +464,9 @@ describe("ZendeskService", () => {
                     const result = await service.getOrganizations(false);
 
                     expect(requestMock).toHaveBeenCalledTimes(1);
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/organizations`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/organizations`
+                    });
                     expect(result).toEqual(organizations);
                 });
             });
@@ -443,7 +478,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getRoles();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/custom_roles`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/custom_roles`
+                    });
                     expect(result).toEqual(custom_roles);
                 });
 
@@ -456,8 +493,12 @@ describe("ZendeskService", () => {
                     const result = await service.getRoles();
 
                     expect(requestMock).toHaveBeenCalledTimes(2);
-                    expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/custom_roles`);
-                    expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                    expect(requestMock).toHaveBeenNthCalledWith(1, {
+                        url: `/api/v2/custom_roles`
+                    });
+                    expect(requestMock).toHaveBeenNthCalledWith(2, {
+                        url: "next_page"
+                    });
                     expect(result).toEqual(custom_roles);
                 });
 
@@ -468,7 +509,9 @@ describe("ZendeskService", () => {
                     const result = await service.getRoles(false);
 
                     expect(requestMock).toHaveBeenCalledTimes(1);
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/custom_roles`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/custom_roles`
+                    });
                     expect(result).toEqual(custom_roles);
                 });
             });
@@ -479,7 +522,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getLocales();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/locales`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/locales`
+                    });
                     expect(result).toEqual(locales);
                 });
             });
@@ -491,7 +536,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getVoiceLines();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/channels/voice/lines`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/channels/voice/lines`
+                    });
                     expect(result).toEqual(lines);
                 });
 
@@ -504,8 +551,12 @@ describe("ZendeskService", () => {
                     const result = await service.getVoiceLines();
 
                     expect(requestMock).toHaveBeenCalledTimes(2);
-                    expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/channels/voice/lines`);
-                    expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                    expect(requestMock).toHaveBeenNthCalledWith(1, {
+                        url: `/api/v2/channels/voice/lines`
+                    });
+                    expect(requestMock).toHaveBeenNthCalledWith(2, {
+                        url: "next_page"
+                    });
                     expect(result).toEqual(lines);
                 });
 
@@ -516,7 +567,9 @@ describe("ZendeskService", () => {
                     const result = await service.getVoiceLines(false);
 
                     expect(requestMock).toHaveBeenCalledTimes(1);
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/channels/voice/lines`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/channels/voice/lines`
+                    });
                     expect(result).toEqual(lines);
                 });
             });
@@ -528,7 +581,9 @@ describe("ZendeskService", () => {
 
                     const result = await service.getMessageHistory();
 
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/channels/sms/message_history.json`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/channels/sms/message_history.json`
+                    });
                     expect(result).toEqual(messages);
                 });
 
@@ -541,8 +596,12 @@ describe("ZendeskService", () => {
                     const result = await service.getMessageHistory();
 
                     expect(requestMock).toHaveBeenCalledTimes(2);
-                    expect(requestMock).toHaveBeenNthCalledWith(1, `/api/v2/channels/sms/message_history.json`);
-                    expect(requestMock).toHaveBeenNthCalledWith(2, "next_page");
+                    expect(requestMock).toHaveBeenNthCalledWith(1, {
+                        url: `/api/v2/channels/sms/message_history.json`
+                    });
+                    expect(requestMock).toHaveBeenNthCalledWith(2, {
+                        url: "next_page"
+                    });
                     expect(result).toEqual(messages);
                 });
 
@@ -553,7 +612,9 @@ describe("ZendeskService", () => {
                     const result = await service.getMessageHistory(false);
 
                     expect(requestMock).toHaveBeenCalledTimes(1);
-                    expect(requestMock).toHaveBeenCalledWith(`/api/v2/channels/sms/message_history.json`);
+                    expect(requestMock).toHaveBeenCalledWith({
+                        url: `/api/v2/channels/sms/message_history.json`
+                    });
                     expect(result).toEqual(messages);
                 });
             });
@@ -579,7 +640,7 @@ describe("ZendeskService", () => {
 
             expect(requestMock).toHaveBeenCalledWith({
                 url: `/api/services/zis/registry/integrations`,
-                method: "GET",
+                type: "GET",
                 contentType: "application/json"
             });
             expect(result).toEqual([zisIntegration]);
@@ -592,7 +653,7 @@ describe("ZendeskService", () => {
 
             expect(requestMock).toHaveBeenCalledWith({
                 url: `/api/services/zis/registry/${zisIntegration.name}`,
-                method: "POST",
+                type: "POST",
                 contentType: "application/json",
                 data: JSON.stringify({
                     description: zisIntegration.description
@@ -773,7 +834,7 @@ describe("ZendeskService", () => {
 
             expect(requestMock).toHaveBeenNthCalledWith(1, {
                 url: `/api/services/zis/registry/integrationName/bundles`,
-                method: "POST",
+                type: "POST",
                 contentType: "application/json",
                 data: JSON.stringify({ name: "zis:bundle" })
             });

--- a/__tests__/utils/create-custom-object.spec.ts
+++ b/__tests__/utils/create-custom-object.spec.ts
@@ -1,6 +1,6 @@
 import { CustomObjectFieldType, ICustomObjectDefinition } from "@models/index";
 import { createCustomObject } from "@utils/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 const getCustomObjectMock = jest.fn();
 const createCustomObjectMock = jest.fn();
@@ -40,7 +40,7 @@ describe("createCustomObject", () => {
         request: requestMock,
         get: getMock,
         metadata: metadataMock
-    } as unknown as Client;
+    } as unknown as IClient;
 
     it("Should do nothing if the settings is not equal to false", async () => {
         metadataMock.mockResolvedValueOnce({
@@ -77,7 +77,7 @@ describe("createCustomObject", () => {
 
         expect(requestMock).toHaveBeenCalledWith({
             url: `/api/v2/apps/installations/12`,
-            method: "PUT",
+            type: "PUT",
             data: {
                 settings: {
                     is_custom_objects_setup_completed: "true"
@@ -170,7 +170,7 @@ describe("createCustomObject", () => {
         expect(createCustomObjectFieldMock).toHaveBeenCalledTimes(1);
         expect(requestMock).toHaveBeenCalledWith({
             url: `/api/v2/apps/installations/12`,
-            method: "PUT",
+            type: "PUT",
             data: {
                 settings: {
                     is_custom_objects_setup_completed: "true"

--- a/__tests__/utils/get-from-client.spec.ts
+++ b/__tests__/utils/get-from-client.spec.ts
@@ -1,5 +1,5 @@
 import { getFromClient } from "@utils/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 describe("Get From Client", () => {
     it("Should return the value from the client", async () => {
@@ -9,7 +9,7 @@ describe("Get From Client", () => {
             get: jest.fn().mockResolvedValue({ [path]: "some value" })
         };
 
-        const result = await getFromClient<string>(mockClient as unknown as Client, path);
+        const result = await getFromClient<string>(mockClient as unknown as IClient, path);
 
         expect(result).toBe("some value");
         expect(mockClient.get).toHaveBeenCalledWith(path);
@@ -23,7 +23,7 @@ describe("Get From Client", () => {
             get: jest.fn().mockResolvedValue({ [path]: "some value", [path2]: "some value 2" })
         };
 
-        const result = await getFromClient<string>(mockClient as unknown as Client, [path, path2]);
+        const result = await getFromClient<string>(mockClient as unknown as IClient, [path, path2]);
 
         expect(result).toStrictEqual({
             path: "some value",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,6 @@
                 "tscpaths": "^0.0.9",
                 "typescript": "^5.9.2",
                 "typescript-eslint": "^8.39.0"
-            },
-            "peerDependencies": {
-                "@zendesk/sell-zaf-app-toolbox": "github:zendesk/sell-zaf-app-toolbox#v2.0.2"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2814,19 +2811,6 @@
             "os": [
                 "win32"
             ]
-        },
-        "node_modules/@zendesk/sell-zaf-app-toolbox": {
-            "version": "2.0.2",
-            "resolved": "git+ssh://git@github.com/zendesk/sell-zaf-app-toolbox.git#c0f451910810bf9ea6980b7cb2504c31f48b83e5",
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "memoize-one": "^5.0.5"
-            },
-            "peerDependencies": {
-                "react": "^16.8.6",
-                "react-dom": "^16.8.6"
-            }
         },
         "node_modules/@zendeskgarden/container-focusvisible": {
             "version": "2.0.6",
@@ -7263,13 +7247,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/memoize-one": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-            "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
         "@zendeskgarden/react-theming": "^8.76.9",
         "react": "^16.14.0"
     },
-    "peerDependencies": {
-        "@zendesk/sell-zaf-app-toolbox": "github:zendesk/sell-zaf-app-toolbox#v2.0.2"
-    },
     "devDependencies": {
         "@eslint/js": "^9.34.0",
         "@testing-library/jest-dom": "^6.6.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "test:ci": "jest --coverage --ci --runInBand --verbose",
         "prettier": "prettier --check .",
         "prettier:fix-all": "prettier --write .",
-        "prettier:fix": "prettier --write $1"
+        "prettier:fix": "prettier --write $1",
+        "prepare": "npm run build"
     },
     "repository": {
         "type": "git",

--- a/src/models/zaf-client.ts
+++ b/src/models/zaf-client.ts
@@ -1,0 +1,71 @@
+export interface IClient {
+    context(): Promise<IContext>;
+    get<T, K extends string = string>(key: K | K[]): Promise<Record<K, T>>;
+    has(event: string, handler: IEventHandler): boolean;
+    instance(guid: string): IClient;
+    invoke<T>(key: string, ...args: any[]): Promise<T>;
+    invoke<T>(obj: Record<string, any[]>): Promise<T>;
+    metadata(): Promise<IMetadata>;
+    off(event: string, handler: IEventHandler): void;
+    on<T>(event: string, handler: IEventHandler<T>, context?: T): void;
+    request<T>(options: IRequestOptions): Promise<T>;
+    set<T, K extends string>(key: K, value: T): Promise<Record<K, T>>;
+    set<T, K extends string>(obj: Record<K, T>): Promise<Record<K, T>>;
+    trigger(event: string, data?: any): void;
+}
+
+export interface IContext {
+    account: {
+        subdomain: string;
+    };
+    instanceGuid: string;
+    location: ISupportAppLocation;
+    product: "support";
+}
+
+export interface IMetadata {
+    appId: number;
+    installationId: number;
+    name: string;
+    settings: ISettings;
+    version: string;
+}
+
+export interface IRequestOptions {
+    accepts?: Record<string, string>;
+    autoRetry?: boolean;
+    cache?: boolean;
+    contentType?: boolean | string;
+    cors?: boolean;
+    crossDomain?: boolean;
+    data?: unknown;
+    dataType?: "json" | "text";
+    headers?: Record<string, string>;
+    httpCompleteResponse?: boolean;
+    ifModified?: boolean;
+    jwt?: Record<string, unknown>;
+    mimeType?: string;
+    secure?: boolean;
+    timeout?: number;
+    traditional?: boolean;
+    type?: IRequestType;
+    url?: string;
+    xhrFields?: Record<string, unknown>;
+}
+
+export type ISettings = Record<string, boolean | number | string>;
+
+export type ISupportAppLocation =
+    | "background"
+    | "modal"
+    | "nav_bar"
+    | "new_ticket_sidebar"
+    | "organization_sidebar"
+    | "ticket_editor"
+    | "ticket_sidebar"
+    | "top_bar"
+    | "user_sidebar";
+
+type IEventHandler<This = any> = (this: This, ...args: any[]) => any;
+
+type IRequestType = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";

--- a/src/services/custom-fields-service.ts
+++ b/src/services/custom-fields-service.ts
@@ -2,7 +2,7 @@ import { MissingCustomFields } from "@errors/index";
 import { ICustomFields, IRequirement } from "@models/index";
 import { ZendeskApiService } from "@services/index";
 import { getFromClient } from "@utils/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 export class CustomFieldsService {
     /**
@@ -16,7 +16,7 @@ export class CustomFieldsService {
     private pathOfIds: string[];
 
     public constructor(
-        private readonly client: Client,
+        private readonly client: IClient,
         private readonly zendeskApiService: ZendeskApiService,
         private readonly identifiers: string[],
         private readonly fetchFromAPI = false

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -20,18 +20,18 @@ import {
     IUpdateCustomObjectFieldAutonumberingPropertiesBody,
     IUpdateCustomObjectFieldBody
 } from "@models/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 const CONTENT_TYPE = "application/json";
 
 export class CustomObjectService {
-    constructor(private readonly client: Client) {}
+    constructor(private readonly client: IClient) {}
 
     /**
      * Create a custom object in the Zendesk instance
      */
     public async createCustomObject(body: ICreateCustomObjectRequestBody): Promise<ICustomObjectResponse> {
-        return this.client.request<any, ICustomObjectResponse>({
+        return this.client.request<ICustomObjectResponse>({
             url: `/api/v2/custom_objects`,
             type: "POST",
             contentType: CONTENT_TYPE,
@@ -45,7 +45,7 @@ export class CustomObjectService {
      * List all custom object created in Zendesk instance
      */
     public async listCustomObjects(): Promise<IListCustomObjectsResponse> {
-        return this.client.request<any, IListCustomObjectsResponse>({
+        return this.client.request<IListCustomObjectsResponse>({
             url: `/api/v2/custom_objects`,
             type: "GET",
             contentType: CONTENT_TYPE
@@ -57,7 +57,7 @@ export class CustomObjectService {
      */
     public async getCustomObject(key: string): Promise<ICustomObjectResponse | undefined> {
         try {
-            return await this.client.request<any, ICustomObjectResponse>({
+            return await this.client.request<ICustomObjectResponse>({
                 url: `/api/v2/custom_objects/${key}`,
                 type: "GET",
                 contentType: CONTENT_TYPE
@@ -71,7 +71,7 @@ export class CustomObjectService {
      * Delete one custom object created in Zendesk Instance
      */
     public async deleteCustomObject(key: string): Promise<void> {
-        return this.client.request<any, void>({
+        return this.client.request<void>({
             url: `/api/v2/custom_objects/${key}`,
             type: "DELETE",
             contentType: CONTENT_TYPE
@@ -85,7 +85,7 @@ export class CustomObjectService {
         key: string,
         include_standard_fields = false
     ): Promise<IListCustomObjectFieldsResponse> {
-        return this.client.request<any, IListCustomObjectFieldsResponse>({
+        return this.client.request<IListCustomObjectFieldsResponse>({
             url: `/api/v2/custom_objects/${key}/fields`,
             type: "GET",
             contentType: CONTENT_TYPE,
@@ -102,7 +102,7 @@ export class CustomObjectService {
         key: string,
         body: ICreateCustomObjectFieldRequestBody
     ): Promise<ICustomObjectFieldResponse> {
-        return this.client.request<any, ICustomObjectFieldResponse>({
+        return this.client.request<ICustomObjectFieldResponse>({
             url: `/api/v2/custom_objects/${key}/fields`,
             type: "POST",
             contentType: CONTENT_TYPE,
@@ -126,7 +126,7 @@ export class CustomObjectService {
         fieldKeyOrId: string,
         body: IUpdateCustomObjectFieldAutonumberingPropertiesBody | IUpdateCustomObjectFieldBody
     ): Promise<ICustomObjectFieldResponse> {
-        return this.client.request<any, ICustomObjectFieldResponse>({
+        return this.client.request<ICustomObjectFieldResponse>({
             url: `/api/v2/custom_objects/${key}/fields/${fieldKeyOrId}`,
             type: "PATCH",
             contentType: CONTENT_TYPE,
@@ -140,7 +140,7 @@ export class CustomObjectService {
      * Delete a custom object field and associate to a custom object
      */
     public async deleteCustomObjectField(customObjectKey: string, fieldKey: string): Promise<void> {
-        return this.client.request<any, void>({
+        return this.client.request<void>({
             url: `/api/v2/custom_objects/${customObjectKey}/fields/${fieldKey}`,
             type: "DELETE",
             contentType: CONTENT_TYPE
@@ -154,7 +154,7 @@ export class CustomObjectService {
         key: string,
         data?: IListFilter
     ): Promise<ICustomObjectRecord<T>[]> {
-        const { custom_object_records } = await this.client.request<any, IListCustomObjectRecordsResponse<T>>({
+        const { custom_object_records } = await this.client.request<IListCustomObjectRecordsResponse<T>>({
             url: `/api/v2/custom_objects/${key}/records`,
             type: "GET",
             contentType: CONTENT_TYPE,
@@ -183,7 +183,7 @@ export class CustomObjectService {
         key: string,
         id: string
     ): Promise<ICustomObjectRecord<T>> {
-        const { custom_object_record } = await this.client.request<any, IGetCustomObjectRecordsResponse<T>>({
+        const { custom_object_record } = await this.client.request<IGetCustomObjectRecordsResponse<T>>({
             url: `/api/v2/custom_objects/${key}/records/${id}`,
             type: "GET",
             contentType: CONTENT_TYPE
@@ -199,7 +199,7 @@ export class CustomObjectService {
         key: string,
         body: ICreateCustomObjectRecordBody<T>
     ): Promise<ICustomObjectRecord<T>> {
-        const { custom_object_record } = await this.client.request<any, IGetCustomObjectRecordsResponse<T>>({
+        const { custom_object_record } = await this.client.request<IGetCustomObjectRecordsResponse<T>>({
             url: `/api/v2/custom_objects/${key}/records`,
             type: "POST",
             contentType: CONTENT_TYPE,
@@ -219,7 +219,7 @@ export class CustomObjectService {
         id: string,
         body: ICreateCustomObjectRecordBody<T>
     ): Promise<ICustomObjectRecord<T>> {
-        const { custom_object_record } = await this.client.request<any, IGetCustomObjectRecordsResponse<T>>({
+        const { custom_object_record } = await this.client.request<IGetCustomObjectRecordsResponse<T>>({
             url: `/api/v2/custom_objects/${key}/records/${id}`,
             type: "PATCH",
             contentType: CONTENT_TYPE,
@@ -243,7 +243,7 @@ export class CustomObjectService {
         body: ISetCustomObjectRecordFieldBody<T>,
         externalId: string
     ): Promise<ICustomObjectRecord<T>> {
-        const { custom_object_record } = await this.client.request<any, IGetCustomObjectRecordsResponse<T>>({
+        const { custom_object_record } = await this.client.request<IGetCustomObjectRecordsResponse<T>>({
             url: `/api/v2/custom_objects/${key}/records?external_id=${externalId}`,
             type: "PATCH",
             contentType: CONTENT_TYPE,
@@ -263,7 +263,7 @@ export class CustomObjectService {
      * Delete custom object record for a custom objects
      */
     public async deleteCustomObjectRecord(key: string, id: string): Promise<void> {
-        return this.client.request<any, void>({
+        return this.client.request<void>({
             url: `/api/v2/custom_objects/${key}/records/${id}`,
             type: "DELETE",
             contentType: CONTENT_TYPE
@@ -346,7 +346,7 @@ export class CustomObjectService {
         if (fetchAllPages) {
             return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records/search`, filter, "POST");
         } else {
-            return this.client.request<any, IListCustomObjectRecordsResponse<T>>({
+            return this.client.request<IListCustomObjectRecordsResponse<T>>({
                 url: `/api/v2/custom_objects/${key}/records/search`,
                 type: "POST",
                 contentType: CONTENT_TYPE,
@@ -365,7 +365,7 @@ export class CustomObjectService {
      * @see https://developer.zendesk.com/api-reference/custom-data/custom-objects/custom_object_records/#custom-object-record-bulk-jobs
      */
     public async bulkJobsForRecords(key: string, job: IBulkJobBody): Promise<IBulkJobResponse> {
-        return this.client.request<any, IBulkJobResponse>({
+        return this.client.request<IBulkJobResponse>({
             url: `/api/v2/custom_objects/${key}/jobs`,
             type: "POST",
             contentType: CONTENT_TYPE,
@@ -410,7 +410,7 @@ export class CustomObjectService {
                 };
             }
 
-            const response = await this.client.request<any, IListCustomObjectRecordsResponse<T>>(options);
+            const response = await this.client.request<IListCustomObjectRecordsResponse<T>>(options);
 
             objects = [...objects, ...response.custom_object_records];
 

--- a/src/services/sunshine-conversation-api-service.ts
+++ b/src/services/sunshine-conversation-api-service.ts
@@ -21,7 +21,7 @@ import {
 } from "@models/index";
 import { buildUrlParams } from "@utils/build-url-params";
 import { INTERNATIONAL_PHONE_NUMBER_REGEX } from "@utils/regex";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 export class SunshineConversationApiService {
     private readonly BASE_URL_V1 = "https://api.smooch.io/v1.1";
@@ -33,7 +33,7 @@ export class SunshineConversationApiService {
 
     public constructor(
         private readonly settings: IServiceConfig,
-        private readonly client: Client
+        private readonly client: IClient
     ) {
         this.publicToken = this.settings.authorizationToken;
         this.useSecure = settings.useSecure;
@@ -104,7 +104,7 @@ export class SunshineConversationApiService {
             })}`;
         }
 
-        return await this.client.request<unknown, IIntegrationsResponse>(this.createV2Options(url, HttpMethod.GET));
+        return await this.client.request<IIntegrationsResponse>(this.createV2Options(url, HttpMethod.GET));
     }
 
     /**
@@ -133,7 +133,7 @@ export class SunshineConversationApiService {
         );
 
         try {
-            let response = await this.client.request<unknown, ITemplatesResponse>(options);
+            let response = await this.client.request<ITemplatesResponse>(options);
             templates = response.messageTemplates ?? [];
 
             while (response.after) {
@@ -141,7 +141,7 @@ export class SunshineConversationApiService {
                     `/apps/${this.settings.appId}/integrations/${whatsAppIntegrationId}/messageTemplates?limit=100&after=${response.after}`,
                     HttpMethod.GET
                 );
-                response = await this.client.request<unknown, ITemplatesResponse>(options);
+                response = await this.client.request<ITemplatesResponse>(options);
                 templates.push(...(response.messageTemplates as ITemplate[]));
             }
         } catch {
@@ -163,7 +163,7 @@ export class SunshineConversationApiService {
             HttpMethod.GET
         );
 
-        const response = await this.client.request<unknown, ITemplatesResponse>(options);
+        const response = await this.client.request<ITemplatesResponse>(options);
 
         if (!response.messageTemplates || response.messageTemplates.length === 0) {
             return;
@@ -184,7 +184,7 @@ export class SunshineConversationApiService {
             HttpMethod.POST,
             createTemplateBody
         );
-        return (await this.client.request<unknown, IResponse<IMessageTemplate>>(options)).responseJSON;
+        return (await this.client.request<IResponse<IMessageTemplate>>(options)).responseJSON;
     }
 
     /**
@@ -195,7 +195,7 @@ export class SunshineConversationApiService {
             `/apps/${this.settings.appId}/integrations/${whatsAppIntegrationId}/messageTemplates/${templateName}`,
             HttpMethod.DELETE
         );
-        await this.client.request<unknown, ITemplatesResponse>(options);
+        await this.client.request<ITemplatesResponse>(options);
     }
 
     /**
@@ -236,7 +236,7 @@ export class SunshineConversationApiService {
             ...(metadata && { metadata })
         };
 
-        const { responseJSON } = await this.client.request<unknown, IResponse<ISendNotification>>(
+        const { responseJSON } = await this.client.request<IResponse<ISendNotification>>(
             this.createV1Options(`/apps/${this.settings.appId}/notifications`, HttpMethod.POST, payload)
         );
 
@@ -256,7 +256,7 @@ export class SunshineConversationApiService {
         triggers: string[],
         includeClient: boolean
     ): Promise<ICreateSuncoWebhookResponse> {
-        return await this.client.request<unknown, ICreateSuncoWebhookResponse>(
+        return await this.client.request<ICreateSuncoWebhookResponse>(
             this.createV1Options(`/apps/${this.settings.appId}/webhooks`, HttpMethod.POST, {
                 target,
                 triggers,

--- a/src/utils/get-from-client.ts
+++ b/src/utils/get-from-client.ts
@@ -1,15 +1,15 @@
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 /**
  * Get a value from the client
  */
-export async function getFromClient<T = unknown>(client: Client, path: string): Promise<T>;
-export async function getFromClient<T = unknown>(client: Client, path: string[]): Promise<Record<string, T>>;
+export async function getFromClient<T = unknown>(client: IClient, path: string): Promise<T>;
+export async function getFromClient<T = unknown>(client: IClient, path: string[]): Promise<Record<string, T>>;
 export async function getFromClient<T = unknown>(
-    client: Client,
+    client: IClient,
     path: string | string[]
 ): Promise<T | Record<string, T>> {
-    const data = await client.get<Record<string, T>>(path);
+    const data = await client.get<T>(path);
 
     if (path instanceof Array) {
         return data;

--- a/src/utils/get-started-chat-event.ts
+++ b/src/utils/get-started-chat-event.ts
@@ -1,19 +1,17 @@
 import { NotFoundError } from "@errors/not-found-error";
 import { IAuditEvent, IAuditResponse } from "@models/index";
-import { Client } from "@zendesk/sell-zaf-app-toolbox";
+import { IClient } from "@models/zaf-client";
 
 /**
  * Get the chat started event from the ticket audits
  *
  * @throws NotFoundError if the chat started event is not found or the ticket audit is not exist.
  */
-export async function getStartedChatEvent(client: Client, ticketId: number): Promise<IAuditEvent> {
-    const settings = {
+export async function getStartedChatEvent(client: IClient, ticketId: number): Promise<IAuditEvent> {
+    const { audits } = await client.request<IAuditResponse>({
         url: `/api/v2/tickets/${ticketId}/audits.json`,
         type: "GET"
-    };
-
-    const { audits } = await client.request<unknown, IAuditResponse>(settings);
+    });
 
     if (!audits) {
         throw new NotFoundError("Failed to get audits");


### PR DESCRIPTION
## Description

This PR introduces a new interface `IClient` to replace the direct dependency on the concrete `Client` type from the `@zendesk/sell-zaf-app-toolbox` package throughout the codebase. This interface abstracts the client API, enhancing type safety, flexibility, and simplifying client mocking in tests.

Key changes:
- Added a new `IClient` interface describing the client API.
- Replaced all imports and typings of `Client` with `IClient` in all services, utilities, and tests.
- Adjusted method calls to use `type` instead of `method` in request options to align with `IClient` interface expectations.
- Updated request argument structures to always use option objects `{ url, ... }` rather than raw URL strings to conform with the `IClient` request signature.
- Removed peer dependency on `@zendesk/sell-zaf-app-toolbox` from `package.json` and cleaned related entries from `package-lock.json`.
- Minor readme update removing legacy peer dep installation flag.
- Added/updated tests to reflect the interface change.
- Manual changes for some service methods to type the requests and responses strictly with generics.
- Overall nit: clean up for HTTP method keys in requests from `method` to `type` for consistency.

This improves code architecture by decoupling from the specific external client implementation while maintaining full request/response typing and unit test compatibility.

## How to manually test

1. Pull the branch and run `npm install` (legacy peer deps flag no longer needed).
2. Run the full test suite: `npm test` or `yarn test` to ensure all tests pass with the new client interface usage.
3. Manually check integration points in the app where `Client` was used to verify all API calls function as expected.
4. Review logs for any unexpected errors in HTTP request handling or metadata fetching.

## Include label

- Version: Major

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested