### PR TITLE
Add Create ticket endpoint to Zendesk API Client

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -841,4 +841,33 @@ describe("ZendeskService", () => {
             expect(requestMock).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("createTicket", () => {
+        it("should create a ticket with the correct data", async () => {
+            await service.createTicket({
+                subject: "test",
+                requester_id: 123,
+                type: "problem",
+                comment: {
+                    body: "Super important issue"
+                }
+            });
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: `/api/v2/tickets`,
+                type: "POST",
+                data: JSON.stringify({
+                    ticket: {
+                        subject: "test",
+                        requester_id: 123,
+                        type: "problem",
+                        comment: {
+                            body: "Super important issue"
+                        }
+                    }
+                })
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -856,7 +856,8 @@ describe("ZendeskService", () => {
             expect(requestMock).toHaveBeenNthCalledWith(1, {
                 url: `/api/v2/tickets.json`,
                 type: "POST",
-                data: {
+                contentType: "application/json",
+                data: JSON.stringify({
                     ticket: {
                         subject: "test",
                         requester_id: 123,
@@ -865,7 +866,7 @@ describe("ZendeskService", () => {
                             body: "Super important issue"
                         }
                     }
-                }
+                })
             });
             expect(requestMock).toHaveBeenCalledTimes(1);
         });

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -854,7 +854,7 @@ describe("ZendeskService", () => {
             });
 
             expect(requestMock).toHaveBeenNthCalledWith(1, {
-                url: `/api/v2/tickets`,
+                url: `/api/v2/tickets.json`,
                 type: "POST",
                 data: {
                     ticket: {

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -854,7 +854,7 @@ describe("ZendeskService", () => {
             });
 
             expect(requestMock).toHaveBeenNthCalledWith(1, {
-                url: `/api/v2/tickets.json`,
+                url: `/api/v2/tickets`,
                 type: "POST",
                 contentType: "application/json",
                 data: JSON.stringify({

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -856,7 +856,7 @@ describe("ZendeskService", () => {
             expect(requestMock).toHaveBeenNthCalledWith(1, {
                 url: `/api/v2/tickets`,
                 type: "POST",
-                data: JSON.stringify({
+                data: {
                     ticket: {
                         subject: "test",
                         requester_id: 123,
@@ -865,7 +865,7 @@ describe("ZendeskService", () => {
                             body: "Super important issue"
                         }
                     }
-                })
+                }
             });
             expect(requestMock).toHaveBeenCalledTimes(1);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "0.14.1",
+    "version": "0.15.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "test:ci": "jest --coverage --ci --runInBand --verbose",
         "prettier": "prettier --check .",
         "prettier:fix-all": "prettier --write .",
-        "prettier:fix": "prettier --write $1"
+        "prettier:fix": "prettier --write $1",
+        "prepare": "npm run build"
     },
     "repository": {
         "type": "git",

--- a/src/models/zendesk-ticket.ts
+++ b/src/models/zendesk-ticket.ts
@@ -43,3 +43,66 @@ export interface ITicketField {
 export interface ITicketFieldResponse {
     ticket_fields: ITicketField[];
 }
+
+interface IZendeskTicketComment {
+    body?: string;
+    public?: boolean;
+    html_body?: string;
+}
+
+interface IZendeskTicketEmailCc {
+    user_id?: number;
+    email?: string;
+    action?: "add" | "remove";
+}
+
+export interface IZendeskTicket {
+    allow_attachments?: boolean; // default true, agents can add attachments to comment
+    allow_channelback?: boolean;
+    assignee_email?: string;
+    assignee_id?: number;
+    attribute_value_ids?: number[];
+    brand_id?: number;
+    collaborator_ids?: number[];
+    collaborators?: { id?: number; email?: string }[];
+    comment?: IZendeskTicketComment;
+    custom_fields?: ITicketField[];
+    custom_status_id?: number;
+    due_at?: string; // ISO 8601 string date
+    email_cc_ids?: number[];
+    email_ccs?: IZendeskTicketEmailCc[];
+    external_id?: string;
+    group_id?: number;
+    macro_id?: number;
+    macro_ids?: number[];
+    metadata?: Record<string, any>; // write only metadata object
+    organization_id?: number;
+    priority?: "urgent" | "high" | "normal" | "low";
+    problem_id?: number;
+    raw_subject?: string;
+    recipient?: string;
+    requester?: {
+        name?: string;
+        email?: string;
+    };
+    requester_id?: number; // mandatory on create
+    safe_update?: boolean;
+    sharing_agreement_ids?: number[];
+    status?: "new" | "open" | "pending" | "hold" | "solved" | "closed";
+    subject?: string;
+    submitter_id?: number;
+    tags?: string[];
+    ticket_form_id?: number;
+    type?: "problem" | "incident" | "question" | "task";
+    via_followup_source_id?: number;
+
+    id: number;
+    created_at: string;
+    updated_at: string;
+    url: string;
+    is_public: boolean;
+}
+
+export interface IZendeskTicketCreateRequest {
+    ticket: IZendeskTicket;
+}

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -27,7 +27,8 @@ import {
     IMessage,
     IMessagesResults,
     IListFilter,
-    ICreateAccessTokenResponse
+    ICreateAccessTokenResponse,
+    IZendeskTicket
 } from "@models/index";
 import {
     ICreateConnectionResponse,
@@ -241,6 +242,26 @@ export class ZendeskApiService {
             }
         });
     }
+
+    /**
+     * Create a ticket
+     *
+     * @link https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#create-ticket
+     * @param ticket The ticket to create
+     * @returns {IZendeskTicket}
+     */
+    public async createTicket(
+        ticket: Omit<IZendeskTicket, "id" | "created_at" | "updated_at" | "url" | "is_public">
+    ): Promise<IZendeskTicket> {
+        return await this.client.request<IZendeskTicket>({
+            url: `/api/v2/tickets`,
+            type: "POST",
+            data: JSON.stringify({
+                ticket
+            })
+        });
+    }
+
     /**
      * Fetch all user instance tags
      */

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -256,9 +256,10 @@ export class ZendeskApiService {
         return await this.client.request<IZendeskTicket>({
             url: "/api/v2/tickets.json",
             type: "POST",
-            data: {
+            contentType: "application/json",
+            data: JSON.stringify({
                 ticket
-            }
+            })
         });
     }
 

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -256,9 +256,9 @@ export class ZendeskApiService {
         return await this.client.request<IZendeskTicket>({
             url: `/api/v2/tickets`,
             type: "POST",
-            data: JSON.stringify({
+            data: {
                 ticket
-            })
+            }
         });
     }
 

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -254,7 +254,7 @@ export class ZendeskApiService {
         ticket: Omit<IZendeskTicket, "id" | "created_at" | "updated_at" | "url" | "is_public">
     ): Promise<IZendeskTicket> {
         return await this.client.request<IZendeskTicket>({
-            url: "/api/v2/tickets.json",
+            url: "/api/v2/tickets",
             type: "POST",
             contentType: "application/json",
             data: JSON.stringify({

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -254,7 +254,7 @@ export class ZendeskApiService {
         ticket: Omit<IZendeskTicket, "id" | "created_at" | "updated_at" | "url" | "is_public">
     ): Promise<IZendeskTicket> {
         return await this.client.request<IZendeskTicket>({
-            url: `/api/v2/tickets`,
+            url: "/api/v2/tickets.json",
             type: "POST",
             data: {
                 ticket


### PR DESCRIPTION
## Description

This PR adds support for creating Zendesk tickets via the API service. It introduces a new method `createTicket` in the `ZendeskApiService` class that allows submitting a ticket creation request. The corresponding `IZendeskTicket` TypeScript interface has been expanded to cover the payload structure including ticket details and metadata. Additionally, a comprehensive test case for the new `createTicket` method has been added to verify correct request formation.

## How to manually test

1. Build and run the project to include the new service method.
2. Use the `ZendeskApiService.createTicket` method with a valid ticket payload.
3. Verify that the HTTP POST request is sent to `/api/v2/tickets` with the correct body.
4. Run the Jest test suite, which now includes the test for ticket creation.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the correct label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?