### PR TITLE
chore: Implement Create many ticket endpoints

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -871,4 +871,38 @@ describe("ZendeskService", () => {
             expect(requestMock).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("createManyTickets", () => {
+        it("should create many tickets with the correct data", async () => {
+            await service.createManyTickets([
+                {
+                    subject: "test",
+                    requester_id: 123,
+                    type: "problem",
+                    comment: {
+                        body: "Super important issue"
+                    }
+                }
+            ]);
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: `/api/v2/create_many`,
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify({
+                    tickets: [
+                        {
+                            subject: "test",
+                            requester_id: 123,
+                            type: "problem",
+                            comment: {
+                                body: "Super important issue"
+                            }
+                        }
+                    ]
+                })
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -28,7 +28,8 @@ import {
     IMessagesResults,
     IListFilter,
     ICreateAccessTokenResponse,
-    IZendeskTicket
+    IZendeskTicket,
+    IBulkJobResponse
 } from "@models/index";
 import {
     ICreateConnectionResponse,
@@ -259,6 +260,31 @@ export class ZendeskApiService {
             contentType: "application/json",
             data: JSON.stringify({
                 ticket
+            })
+        });
+    }
+
+    /**
+     * Create many tickets
+     * A limit of 100 tickets can be created at a time.
+     *
+     * @link https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#create-ticket
+     * @param ticket The ticket to create
+     * @returns {IZendeskTicket}
+     */
+    public async createManyTickets(
+        tickets: Omit<IZendeskTicket, "id" | "created_at" | "updated_at" | "url" | "is_public">[]
+    ): Promise<IBulkJobResponse> {
+        if (tickets.length > 100) {
+            throw new Error("A limit of 100 tickets can be created at a time.");
+        }
+
+        return await this.client.request<IBulkJobResponse>({
+            url: "/api/v2/create_many",
+            type: "POST",
+            contentType: "application/json",
+            data: JSON.stringify({
+                tickets
             })
         });
     }


### PR DESCRIPTION
## Description

This PR introduces the `createManyTickets` method to the Zendesk API service, enabling the creation of multiple tickets in a single request (up to a limit of 100 tickets). The method sends a POST request to the `/api/v2/create_many` endpoint with the tickets data. Corresponding tests have been added to verify the functionality of this new method.

## How to manually test

1. Use the updated Zendesk API service that includes the `createManyTickets` method.
2. Call `createManyTickets` with an array of ticket objects (with subject, requester_id, type, and comment).
3. Verify that the service sends the correct POST request to `/api/v2/create_many`.
4. Confirm appropriate handling of the 100-ticket limit by passing more than 100 tickets and expecting an error.

## Include label

- Version: Minor

## Acceptation criteria

- [x] Added the correct label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?