### PR TITLE
chore: Implement get tickets endpoints

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -220,7 +220,7 @@ describe("ZendeskService", () => {
                 const result = await service.getZendeskTickets([1, 2]);
 
                 expect(requestMock).toHaveBeenCalledWith({
-                    url: `/api/v2/tickets/show_many?id=1,2`,
+                    url: `/api/v2/tickets/show_many?ids=1,2`,
                     type: "GET",
                     contentType: "application/json"
                 });
@@ -233,23 +233,11 @@ describe("ZendeskService", () => {
                 const result = await service.getZendeskTickets([999]);
 
                 expect(requestMock).toHaveBeenCalledWith({
-                    url: `/api/v2/tickets/show_many?id=999`,
+                    url: `/api/v2/tickets/show_many?ids=999`,
                     type: "GET",
                     contentType: "application/json"
                 });
                 expect(result).toEqual([]);
-            });
-
-            it("should return tickets array from the API response", async () => {
-                const apiResponse = { tickets: mockTickets };
-                requestMock.mockResolvedValueOnce(apiResponse);
-
-                const result = await service.getZendeskTickets([1, 2]);
-
-                expect(result).toBe(apiResponse.tickets);
-                expect(result).toHaveLength(2);
-                expect(result[0]).toEqual(mockTickets[0]);
-                expect(result[1]).toEqual(mockTickets[1]);
             });
 
             it("should throw an error when trying to retrieve more than 100 tickets", async () => {

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -204,7 +204,7 @@ describe("ZendeskService", () => {
                 },
                 {
                     id: 2,
-                    subject: "Test ticket 2", 
+                    subject: "Test ticket 2",
                     created_at: "2023-01-02T00:00:00Z",
                     updated_at: "2023-01-02T00:00:00Z",
                     url: "https://example.zendesk.com/api/v2/tickets/2.json",
@@ -227,20 +227,6 @@ describe("ZendeskService", () => {
                 expect(result).toEqual(mockTickets);
             });
 
-            it("should retrieve a single ticket", async () => {
-                const singleTicket = [mockTickets[0]];
-                requestMock.mockResolvedValueOnce({ tickets: singleTicket });
-
-                const result = await service.getZendeskTickets([1]);
-
-                expect(requestMock).toHaveBeenCalledWith({
-                    url: `/api/v2/tickets/show_many?id=1`,
-                    type: "GET",
-                    contentType: "application/json"
-                });
-                expect(result).toEqual(singleTicket);
-            });
-
             it("should handle empty ticket array", async () => {
                 requestMock.mockResolvedValueOnce({ tickets: [] });
 
@@ -254,19 +240,6 @@ describe("ZendeskService", () => {
                 expect(result).toEqual([]);
             });
 
-            it("should handle multiple ticket IDs correctly", async () => {
-                requestMock.mockResolvedValueOnce({ tickets: mockTickets });
-
-                const result = await service.getZendeskTickets([1, 2, 3, 4, 5]);
-
-                expect(requestMock).toHaveBeenCalledWith({
-                    url: `/api/v2/tickets/show_many?id=1,2,3,4,5`,
-                    type: "GET",
-                    contentType: "application/json"
-                });
-                expect(result).toEqual(mockTickets);
-            });
-
             it("should return tickets array from the API response", async () => {
                 const apiResponse = { tickets: mockTickets };
                 requestMock.mockResolvedValueOnce(apiResponse);
@@ -277,6 +250,16 @@ describe("ZendeskService", () => {
                 expect(result).toHaveLength(2);
                 expect(result[0]).toEqual(mockTickets[0]);
                 expect(result[1]).toEqual(mockTickets[1]);
+            });
+
+            it("should throw an error when trying to retrieve more than 100 tickets", async () => {
+                const manyTicketIds = Array.from({ length: 101 }, (_, index) => index + 1);
+
+                await expect(service.getZendeskTickets(manyTicketIds)).rejects.toThrow(
+                    "A limit of 100 tickets can be retrieved at a time."
+                );
+
+                expect(requestMock).not.toHaveBeenCalled();
             });
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/zendesk-ticket.ts
+++ b/src/models/zendesk-ticket.ts
@@ -10,6 +10,10 @@ export interface IAssignee {
     user: IZendeskUser;
 }
 
+export interface ITicketsResults {
+    tickets: IZendeskTicket[];
+}
+
 export interface ITicketCustomField {
     id: string;
     value: string;

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -29,7 +29,8 @@ import {
     IListFilter,
     ICreateAccessTokenResponse,
     IZendeskTicket,
-    IBulkJobResponse
+    IBulkJobResponse,
+    ITicketsResults
 } from "@models/index";
 import {
     ICreateConnectionResponse,
@@ -97,6 +98,19 @@ export class ZendeskApiService {
         } catch {
             throw new NotFoundError(requirementIdentifier);
         }
+    }
+
+    /**
+     * Retrieve multiple zendesk tickets
+     */
+    public async getZendeskTickets(ticketIds: number[]): Promise<IZendeskTicket[]> {
+        const { tickets } = await this.client.request<ITicketsResults>({
+            url: `/api/v2/tickets/show_many?id=${ticketIds.join(",")}`,
+            type: "GET",
+            contentType: "application/json"
+        });
+
+        return tickets;
     }
 
     /**

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -49,6 +49,11 @@ import { IClient } from "@models/zaf-client";
  */
 export const UPDATE_USER_FIELD_MAX_USERS = 90;
 
+/**
+ * Maximum number of tickets that can be retrieved at a time
+ */
+export const MAX_TICKETS_PER_REQUEST = 100;
+
 export class ZendeskApiService {
     public constructor(public client: IClient) {}
 
@@ -105,7 +110,7 @@ export class ZendeskApiService {
      * A limit of 100 tickets can be retrieved at a time.
      */
     public async getZendeskTickets(ticketIds: number[]): Promise<IZendeskTicket[]> {
-        if (ticketIds.length > 100) {
+        if (ticketIds.length > MAX_TICKETS_PER_REQUEST) {
             throw new Error("A limit of 100 tickets can be retrieved at a time.");
         }
 
@@ -294,7 +299,7 @@ export class ZendeskApiService {
     public async createManyTickets(
         tickets: Omit<IZendeskTicket, "id" | "created_at" | "updated_at" | "url" | "is_public">[]
     ): Promise<IBulkJobResponse> {
-        if (tickets.length > 100) {
+        if (tickets.length > MAX_TICKETS_PER_REQUEST) {
             throw new Error("A limit of 100 tickets can be created at a time.");
         }
 

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -102,8 +102,13 @@ export class ZendeskApiService {
 
     /**
      * Retrieve multiple zendesk tickets
+     * A limit of 100 tickets can be retrieved at a time.
      */
     public async getZendeskTickets(ticketIds: number[]): Promise<IZendeskTicket[]> {
+        if (ticketIds.length > 100) {
+            throw new Error("A limit of 100 tickets can be retrieved at a time.");
+        }
+
         const { tickets } = await this.client.request<ITicketsResults>({
             url: `/api/v2/tickets/show_many?id=${ticketIds.join(",")}`,
             type: "GET",

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -110,7 +110,7 @@ export class ZendeskApiService {
         }
 
         const { tickets } = await this.client.request<ITicketsResults>({
-            url: `/api/v2/tickets/show_many?id=${ticketIds.join(",")}`,
+            url: `/api/v2/tickets/show_many?ids=${ticketIds.join(",")}`,
             type: "GET",
             contentType: "application/json"
         });


### PR DESCRIPTION
## Description

This PR introduces the `getZendeskTickets` method to the Zendesk API service, enabling the fetch of multiple tickets in a single request (up to a limit of 100 tickets). The method sends a GET request to the `/api/v2/show_many` endpoint with the tickets data. Corresponding tests have been added to verify the functionality of this new method.

## How to manually test

1. Use the updated Zendesk API service that includes the `getZendeskTickets` method.
2. Call `getZendeskTickets` with an array of ticket IDs.
3. Verify that the service sends the correct POST request to `/api/v2/show_many`.
4. Confirm appropriate handling of the 100-ticket limit by passing more than 100 tickets and expecting an error.

## Include label

- Version: Patch

## Acceptation criteria

- [x] Added the correct label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?