### PR TITLE
feat: Implement new method use with Zis connection

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -1072,6 +1072,78 @@ describe("ZendeskService", () => {
         });
     });
 
+    describe("getZisOAuthConnection", () => {
+        const oauthConnection = {
+            access_token: "access_token_value",
+            created_by: "user@example.com",
+            integration: "integrationName",
+            name: "my_connection",
+            uuid: "uuid-1234",
+            token_expiry: "2026-12-31T00:00:00Z",
+            token_type: "bearer",
+            refresh_token: "refresh_token_value"
+        };
+
+        it("should fetch an OAuth connection without optional params", async () => {
+            requestMock.mockResolvedValueOnce(oauthConnection);
+
+            const result = await service.getZisOAuthConnection("integrationName");
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/services/zis/connections/integrationName`,
+                type: "GET",
+                contentType: "application/json"
+            });
+            expect(result).toEqual(oauthConnection);
+        });
+
+        it("should fetch an OAuth connection with uuid param", async () => {
+            requestMock.mockResolvedValueOnce(oauthConnection);
+
+            const result = await service.getZisOAuthConnection("integrationName", { uuid: "uuid-1234" });
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/services/zis/connections/integrationName?uuid=uuid-1234`,
+                type: "GET",
+                contentType: "application/json"
+            });
+            expect(result).toEqual(oauthConnection);
+        });
+
+        it("should fetch an OAuth connection with name param", async () => {
+            requestMock.mockResolvedValueOnce(oauthConnection);
+
+            const result = await service.getZisOAuthConnection("integrationName", { name: "my_connection" });
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/services/zis/connections/integrationName?name=my_connection`,
+                type: "GET",
+                contentType: "application/json"
+            });
+            expect(result).toEqual(oauthConnection);
+        });
+    });
+
+    describe("startZisOAuthFlow", () => {
+        const oauthStartResponse = {
+            redirect_url: "https://oauth.example.com/authorize?flow_token=abc123",
+            flow_token: "abc123"
+        };
+
+        it("should start the OAuth flow with the correct data", async () => {
+            requestMock.mockResolvedValueOnce(oauthStartResponse);
+
+            const result = await service.startZisOAuthFlow("integrationName");
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/services/zis/connections/oauth/start/integrationName`,
+                type: "POST",
+                contentType: "application/json"
+            });
+            expect(result).toEqual(oauthStartResponse);
+        });
+    });
+
     describe("createTicket", () => {
         it("should create a ticket with the correct data", async () => {
             requestMock.mockResolvedValueOnce({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -68,3 +68,19 @@ export interface ICreateInboundWebhookResponse {
     username: string;
     password: string;
 }
+
+export interface IZisOAuthConnection {
+    access_token: string;
+    created_by: string;
+    integration: string;
+    name: string;
+    uuid: string;
+    token_expiry: string;
+    token_type: string;
+    refresh_token: string;
+}
+
+export interface IZisOAuthStartResponse {
+    redirect_url: string;
+    flow_token: string;
+}

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -44,7 +44,9 @@ import {
     IZisIntegration,
     IZisIntegrationResponse,
     IZisJobspec,
-    IZisJobspecsResponse
+    IZisJobspecsResponse,
+    IZisOAuthConnection,
+    IZisOAuthStartResponse
 } from "@models/zendesk-integration-services";
 import { convertContentMessageToHtml } from "@utils/convert-content-message-to-html";
 import { getFromClient } from "@utils/get-from-client";
@@ -658,6 +660,43 @@ export class ZendeskApiService {
             type: "POST",
             contentType: "application/json",
             data: JSON.stringify(bundle)
+        });
+    }
+
+    /**
+     * Returns connection details for a ZIS OAuth integration.
+     *
+     * @param {string} integrationName - The name of the ZIS integration.
+     * @param {object} [options] - Optional filters. Specify either uuid or name, not both.
+     * @param {string} [options.uuid] - The UUID of the connection.
+     * @param {string} [options.name] - The name of the connection.
+     * @returns {Promise<IZisOAuthConnection>} - The OAuth connection details.
+     */
+    public async getZisOAuthConnection(
+        integrationName: string,
+        options?: { uuid?: string; name?: string }
+    ): Promise<IZisOAuthConnection> {
+        const queryParams = options ? buildUrlParams(options) : "";
+        const url = `/api/services/zis/connections/${integrationName}${queryParams ? `?${queryParams}` : ""}`;
+
+        return await this.client.request<IZisOAuthConnection>({
+            url,
+            type: "GET",
+            contentType: "application/json"
+        });
+    }
+
+    /**
+     * Starts the OAuth flow for a ZIS integration.
+     *
+     * @param {string} integrationName - The name of the ZIS integration.
+     * @returns {Promise<IZisOAuthStartResponse>} - The response containing the redirect URL and flow token.
+     */
+    public async startZisOAuthFlow(integrationName: string): Promise<IZisOAuthStartResponse> {
+        return await this.client.request<IZisOAuthStartResponse>({
+            url: `/api/services/zis/connections/oauth/start/${integrationName}`,
+            type: "POST",
+            contentType: "application/json"
         });
     }
 


### PR DESCRIPTION
## Description

This PR adds support for ZIS OAuth connection management in the Zendesk API service.

### Changes made
- Added a new method to fetch ZIS OAuth connection details:
  - `getZisOAuthConnection(integrationName, options?)`
  - Supports filtering by either `uuid` or `name`
- Added a new method to start the OAuth flow:
  - `startZisOAuthFlow(integrationName)`
- Added new TypeScript models for the OAuth responses:
  - `IZisOAuthConnection`
  - `IZisOAuthStartResponse`
- Added unit tests covering:
  - fetching an OAuth connection without optional params
  - fetching an OAuth connection by `uuid`
  - fetching an OAuth connection by `name`
  - starting the OAuth flow

<!-- If this is a UI change, please add some screenshots of the change using the <details><summary></summary></details> tags -->

## How to manually test

1. Install the updated application version.
2. Use a Zendesk instance with ZIS enabled.
3. Call `getZisOAuthConnection("integrationName")` and verify the connection details are returned.
4. Call `getZisOAuthConnection("integrationName", { uuid: "..." })` and confirm the request includes the `uuid` query parameter.
5. Call `getZisOAuthConnection("integrationName", { name: "..." })` and confirm the request includes the `name` query parameter.
6. Call `startZisOAuthFlow("integrationName")` and verify the response includes the redirect URL and flow token.

## Include label

Please add one of the following labels based on the scope of this change:

- Version: Major
- Version: Minor
- Version: Patch

**Suggested label:** `Version: Minor`

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?