### PR TITLE
chore: Add body to Oauth endpoint

### DIFF
--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -1133,12 +1133,20 @@ describe("ZendeskService", () => {
         it("should start the OAuth flow with the correct data", async () => {
             requestMock.mockResolvedValueOnce(oauthStartResponse);
 
-            const result = await service.startZisOAuthFlow("integrationName");
+            const options = {
+                name: "zendesk",
+                oauth_client_name: "zendesk",
+                oauth_url_subdomain: "mycompany",
+                origin_oauth_redirect_url: "https://mycompany.zendesk.com/agent/apps/relay"
+            };
+
+            const result = await service.startZisOAuthFlow("integrationName", options);
 
             expect(requestMock).toHaveBeenCalledWith({
                 url: `/api/services/zis/connections/oauth/start/integrationName`,
                 type: "POST",
-                contentType: "application/json"
+                contentType: "application/json",
+                data: JSON.stringify(options)
             });
             expect(result).toEqual(oauthStartResponse);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -80,6 +80,13 @@ export interface IZisOAuthConnection {
     refresh_token: string;
 }
 
+export interface IZisOAuthStartOptions {
+    name: string;
+    oauth_client_name: string;
+    oauth_url_subdomain: string;
+    origin_oauth_redirect_url: string;
+}
+
 export interface IZisOAuthStartResponse {
     redirect_url: string;
     flow_token: string;

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -46,6 +46,7 @@ import {
     IZisJobspec,
     IZisJobspecsResponse,
     IZisOAuthConnection,
+    IZisOAuthStartOptions,
     IZisOAuthStartResponse
 } from "@models/zendesk-integration-services";
 import { convertContentMessageToHtml } from "@utils/convert-content-message-to-html";
@@ -690,13 +691,18 @@ export class ZendeskApiService {
      * Starts the OAuth flow for a ZIS integration.
      *
      * @param {string} integrationName - The name of the ZIS integration.
+     * @param {IZisOAuthStartOptions} options - The OAuth connection parameters.
      * @returns {Promise<IZisOAuthStartResponse>} - The response containing the redirect URL and flow token.
      */
-    public async startZisOAuthFlow(integrationName: string): Promise<IZisOAuthStartResponse> {
+    public async startZisOAuthFlow(
+        integrationName: string,
+        options: IZisOAuthStartOptions
+    ): Promise<IZisOAuthStartResponse> {
         return await this.client.request<IZisOAuthStartResponse>({
             url: `/api/services/zis/connections/oauth/start/${integrationName}`,
             type: "POST",
-            contentType: "application/json"
+            contentType: "application/json",
+            data: JSON.stringify(options)
         });
     }
 


### PR DESCRIPTION
## Description

This PR updates the ZIS OAuth start flow to accept and send the required OAuth connection parameters in the request body.

### What changed
- Added a new `IZisOAuthStartOptions` interface to define the OAuth start payload.
- Updated `startZisOAuthFlow` to accept an `options` argument and send it as JSON in the POST request.
- Updated the unit test to validate the request now includes the serialized payload.

<!-- If this is a UI change, please add some screenshots of the change using the <details><summary></summary></details> tags -->

## How to manually test

1. Install the target version of the app.
2. Trigger the ZIS OAuth start flow from the integration setup or via the service method.
3. Confirm the request to `/api/services/zis/connections/oauth/start/:integrationName` is sent with:
   - `type: "POST"`
   - `contentType: "application/json"`
   - a JSON body containing:
     - `name`
     - `oauth_client_name`
     - `oauth_url_subdomain`
     - `origin_oauth_redirect_url`
4. Confirm the API returns the expected `redirect_url` and `flow_token`.

## Include label

This change adds a new required request payload to an existing service method, which is a backward-incompatible API change for callers of `startZisOAuthFlow`.

- Version: Patch

## Acceptation criteria

- [x] Added the corrected label to my pull request
- [x] Added/updated tests impacted by the change
- [x] Documentation is up-to-date (README.md / INSTALL.md)
- [x] Manually tested?