### PR TITLE
feat: Add Sunco webhook management calls and interfaces

### DIFF
--- a/__tests__/services/sunshine-conversation-api-service.spec.ts
+++ b/__tests__/services/sunshine-conversation-api-service.spec.ts
@@ -10,6 +10,8 @@ import {
     IIntegrationWhatsApp,
     ISendNotificationPayload,
     IServiceConfig,
+    ISuncoWebhook,
+    IUpdateSuncoWebhookPayload,
     UserChannelTypes
 } from "@models/sunshine-conversation";
 import { ICreateTemplate, IMessageTemplate, IResponse, ITemplate, TemplateStatus } from "@models/whats-app-template";
@@ -547,6 +549,106 @@ describe("SunshineConversationApiService", () => {
             };
 
             await sunshineConversationApiService.createWebhook("target", ["event1", "event2"], true);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+        });
+    });
+
+    describe("listWebhooks", () => {
+        const webhookSample: ISuncoWebhook = {
+            _id: "webhook-id-1",
+            version: "v1.1",
+            triggers: ["message:appUser"],
+            target: "https://example.com/webhook",
+            secret: "secret123",
+            includeFullAppUser: false,
+            includeClient: true
+        };
+
+        it("should call the API and return the list of webhooks", async () => {
+            client.request.mockResolvedValueOnce({ webhooks: [webhookSample] });
+
+            const options = {
+                url: `https://api.smooch.io/v1.1/apps/suncoAppId/webhooks`,
+                type: HttpMethod.GET,
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            const result = await sunshineConversationApiService.listWebhooks();
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(webhookSample);
+        });
+
+        it("should return an empty array when no webhooks key is present", async () => {
+            client.request.mockResolvedValueOnce({});
+
+            const result = await sunshineConversationApiService.listWebhooks();
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("updateWebhook", () => {
+        it("should call the API with the correct options and return the updated webhook", async () => {
+            const webhookId = "webhook-id-1";
+            const payload: IUpdateSuncoWebhookPayload = {
+                target: "https://example.com/new-target",
+                triggers: ["message:appUser", "message:appMaker"]
+            };
+            const updatedWebhook = {
+                webhook: {
+                    _id: webhookId,
+                    version: "v1.1",
+                    triggers: payload.triggers,
+                    target: payload.target,
+                    secret: "secret123",
+                    includeFullAppUser: false,
+                    includeClient: false
+                }
+            };
+            client.request.mockResolvedValueOnce(updatedWebhook);
+
+            const options = {
+                url: `https://api.smooch.io/v1.1/apps/suncoAppId/webhooks/${webhookId}`,
+                type: HttpMethod.PUT,
+                contentType: "application/json",
+                data: JSON.stringify(payload),
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                httpCompleteResponse: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            const result = await sunshineConversationApiService.updateWebhook(webhookId, payload);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result).toBe(updatedWebhook);
+        });
+    });
+
+    describe("deleteWebhook", () => {
+        it("should call the DELETE API with the correct options", async () => {
+            const webhookId = "webhook-id-1";
+
+            const options = {
+                url: `https://api.smooch.io/v1.1/apps/suncoAppId/webhooks/${webhookId}`,
+                type: HttpMethod.DELETE,
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            await sunshineConversationApiService.deleteWebhook(webhookId);
 
             expect(client.request).toHaveBeenCalledWith(options);
         });

--- a/__tests__/services/zendesk-api-service.spec.ts
+++ b/__tests__/services/zendesk-api-service.spec.ts
@@ -1056,6 +1056,65 @@ describe("ZendeskService", () => {
         });
     });
 
+    describe("listZisInboundWebhooks", () => {
+        const inboundWebhookSample = {
+            id: "1",
+            uuid: "uuid-abc-123",
+            zendesk_account_id: 42,
+            path: "/api/services/zis/inbound_webhooks/generic/integrationName/uuid-abc-123",
+            integration: "integrationName",
+            source_system: "my-system",
+            event_type: "ticket.created"
+        };
+
+        it("should fetch all inbound webhooks for the integration", async () => {
+            requestMock.mockResolvedValueOnce({ inbound_webhooks: [inboundWebhookSample] });
+
+            const result = await service.listZisInboundWebhooks("integrationName");
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: "/api/services/zis/inbound_webhooks/generic/integrationName/all",
+                type: "GET",
+                contentType: "application/json"
+            });
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual(inboundWebhookSample);
+        });
+
+        it("should return an empty array when no inbound_webhooks key is present", async () => {
+            requestMock.mockResolvedValueOnce({});
+
+            const result = await service.listZisInboundWebhooks("integrationName");
+
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("showZisInboundWebhook", () => {
+        const inboundWebhookSample = {
+            id: "1",
+            uuid: "uuid-abc-123",
+            zendesk_account_id: 42,
+            path: "/api/services/zis/inbound_webhooks/generic/integrationName/uuid-abc-123",
+            integration: "integrationName",
+            source_system: "my-system",
+            event_type: "ticket.created"
+        };
+
+        it("should fetch a single inbound webhook by UUID", async () => {
+            requestMock.mockResolvedValueOnce(inboundWebhookSample);
+
+            const result = await service.showZisInboundWebhook("integrationName", "uuid-abc-123");
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: "/api/services/zis/inbound_webhooks/generic/integrationName/uuid-abc-123",
+                type: "GET",
+                contentType: "application/json"
+            });
+            expect(result).toEqual(inboundWebhookSample);
+        });
+    });
+
     describe("uploadZisBundle", () => {
         it("should upload a Zis bundle with the correct data", async () => {
             await service.uploadZisBundle("integrationName", {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.8.0",
+    "version": "1.7.1",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.7.1",
+    "version": "1.8.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/sunshine-conversation.ts
+++ b/src/models/sunshine-conversation.ts
@@ -774,7 +774,7 @@ export interface ISunshineConversationGetIntegrationsFilters {
     types: string;
 }
 
-export interface ISuncoWebhookResponseWebhook {
+export interface ISuncoWebhook {
     _id: string;
     version: string;
     triggers: string[];
@@ -785,17 +785,7 @@ export interface ISuncoWebhookResponseWebhook {
 }
 
 export interface ICreateSuncoWebhookResponse {
-    webhook: ISuncoWebhookResponseWebhook;
-}
-
-export interface ISuncoWebhook {
-    _id: string;
-    version: string;
-    triggers: string[];
-    target: string;
-    secret: string;
-    includeFullAppUser: boolean;
-    includeClient: boolean;
+    webhook: ISuncoWebhook;
 }
 
 export interface IUpdateSuncoWebhookPayload {

--- a/src/models/sunshine-conversation.ts
+++ b/src/models/sunshine-conversation.ts
@@ -787,3 +787,19 @@ export interface ISuncoWebhookResponseWebhook {
 export interface ICreateSuncoWebhookResponse {
     webhook: ISuncoWebhookResponseWebhook;
 }
+
+export interface ISuncoWebhook {
+    _id: string;
+    version: string;
+    triggers: string[];
+    target: string;
+    secret: string;
+    includeFullAppUser: boolean;
+    includeClient: boolean;
+}
+
+export interface IUpdateSuncoWebhookPayload {
+    target?: string;
+    triggers?: string[];
+    includeClient?: boolean;
+}

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -69,6 +69,21 @@ export interface ICreateInboundWebhookResponse {
     password: string;
 }
 
+/**
+ * A ZIS inbound webhook record as returned by the read/list endpoints.
+ * Credentials (username/password) are omitted — only the creation response
+ * exposes them.
+ */
+export interface IZisInboundWebhook {
+    id: string;
+    uuid: string;
+    zendesk_account_id: number;
+    path: string;
+    integration: string;
+    source_system: string;
+    event_type: string;
+}
+
 export interface IZisOAuthConnection {
     access_token: string;
     created_by: string;

--- a/src/models/zendesk-integration-services.ts
+++ b/src/models/zendesk-integration-services.ts
@@ -69,11 +69,6 @@ export interface ICreateInboundWebhookResponse {
     password: string;
 }
 
-/**
- * A ZIS inbound webhook record as returned by the read/list endpoints.
- * Credentials (username/password) are omitted — only the creation response
- * exposes them.
- */
 export interface IZisInboundWebhook {
     id: string;
     uuid: string;

--- a/src/services/sunshine-conversation-api-service.ts
+++ b/src/services/sunshine-conversation-api-service.ts
@@ -17,7 +17,9 @@ import {
     IMetadata,
     IMessageTemplate,
     ISendNotification,
-    ICreateSuncoWebhookResponse
+    ICreateSuncoWebhookResponse,
+    ISuncoWebhook,
+    IUpdateSuncoWebhookPayload
 } from "@models/index";
 import { buildUrlParams } from "@utils/build-url-params";
 import { INTERNATIONAL_PHONE_NUMBER_REGEX } from "@utils/regex";
@@ -262,6 +264,46 @@ export class SunshineConversationApiService {
                 triggers,
                 includeClient
             })
+        );
+    }
+
+    /**
+     * List all webhooks registered for the application.
+     *
+     * @link https://docs.smooch.io/rest/#tag/Webhooks/operation/listWebhooks
+     * @returns Array of webhooks, or an empty array if none are configured
+     */
+    public async listWebhooks(): Promise<ISuncoWebhook[]> {
+        const response = await this.client.request<{ webhooks: ISuncoWebhook[] }>(
+            this.createV1Options(`/apps/${this.settings.appId}/webhooks`, HttpMethod.GET)
+        );
+        return response.webhooks ?? [];
+    }
+
+    /**
+     * Update an existing webhook for the application.
+     *
+     * @param webhookId - The ID of the webhook to update
+     * @param payload - The fields to update on the webhook
+     * @returns The updated webhook wrapped in the standard response envelope
+     */
+    public async updateWebhook(
+        webhookId: string,
+        payload: IUpdateSuncoWebhookPayload
+    ): Promise<ICreateSuncoWebhookResponse> {
+        return await this.client.request<ICreateSuncoWebhookResponse>(
+            this.createV1Options(`/apps/${this.settings.appId}/webhooks/${webhookId}`, HttpMethod.PUT, payload)
+        );
+    }
+
+    /**
+     * Delete a webhook from the application.
+     *
+     * @param webhookId - The ID of the webhook to delete
+     */
+    public async deleteWebhook(webhookId: string): Promise<void> {
+        await this.client.request(
+            this.createV1Options(`/apps/${this.settings.appId}/webhooks/${webhookId}`, HttpMethod.DELETE)
         );
     }
 }

--- a/src/services/zendesk-api-service.ts
+++ b/src/services/zendesk-api-service.ts
@@ -41,6 +41,7 @@ import {
     ICreateConnectionResponse,
     ICreateInboundWebhookResponse,
     ICreateZisBasicAuthConnection,
+    IZisInboundWebhook,
     IZisIntegration,
     IZisIntegrationResponse,
     IZisJobspec,
@@ -703,6 +704,40 @@ export class ZendeskApiService {
             type: "POST",
             contentType: "application/json",
             data: JSON.stringify(options)
+        });
+    }
+
+    /**
+     * List all ZIS inbound webhooks for a given integration.
+     *
+     * @note This endpoint is undocumented but functional. It aggregates all
+     * inbound webhook records for the integration under the `/all` path.
+     *
+     * @param integrationName - The name of the ZIS integration
+     * @returns Array of inbound webhooks, or an empty array if none exist
+     */
+    public async listZisInboundWebhooks(integrationName: string): Promise<IZisInboundWebhook[]> {
+        const response = await this.client.request<{ inbound_webhooks: IZisInboundWebhook[] }>({
+            url: `/api/services/zis/inbound_webhooks/generic/${integrationName}/all`,
+            type: "GET",
+            contentType: "application/json"
+        });
+        return response.inbound_webhooks ?? [];
+    }
+
+    /**
+     * Retrieve a single ZIS inbound webhook by UUID.
+     *
+     * @link https://developer.zendesk.com/api-reference/integration-services/inbound-webhooks/inbound_webhooks/#show-inbound-webhook-by-uuid
+     * @param integrationName - The name of the ZIS integration
+     * @param uuid - The UUID of the inbound webhook
+     * @returns The inbound webhook record
+     */
+    public async showZisInboundWebhook(integrationName: string, uuid: string): Promise<IZisInboundWebhook> {
+        return await this.client.request<IZisInboundWebhook>({
+            url: `/api/services/zis/inbound_webhooks/generic/${integrationName}/${uuid}`,
+            type: "GET",
+            contentType: "application/json"
         });
     }
 


### PR DESCRIPTION
## Description

- Adds listWebhooks(), updateWebhook(), and deleteWebhook() to SunshineConversationApiService, covering the GET/PUT/DELETE /v1.1/apps/{appId}/webhooks Sunco endpoints. Exports ISuncoWebhook and IUpdateSuncoWebhookPayload from the model barrel.
- Adds listZisInboundWebhooks() and showZisInboundWebhook() to ZendeskApiService, covering the ZIS inbound-webhook list (undocumented /all path) and show-by-UUID endpoints. Exports IZisInboundWebhook (credentials omitted) from the ZIS model file.