### PR TITLE
chore: Remove Garden and styled-components dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "@zendesk/zaf-toolbox",
             "version": "1.7.1",
             "license": "Apache-2.0",
-            "dependencies": {
-                "@zendeskgarden/react-theming": "^8.76.9"
-            },
             "devDependencies": {
                 "@eslint/js": "^9.39.0",
                 "@testing-library/jest-dom": "^6.9.1",
@@ -18,7 +15,7 @@
                 "@types/jest": "^30.0.0",
                 "@types/lodash": "^4.17.20",
                 "@types/node": "^24.9.1",
-                "@types/styled-components": "^5.1.36",
+                "@types/react": "^19.2.16",
                 "@typescript-eslint/parser": "^8.49.0",
                 "del": "^8.0.1",
                 "eslint": "^9.39.2",
@@ -33,7 +30,6 @@
                 "prettier": "^3.7.4",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "styled-components": "^5.3.11",
                 "ts-jest": "^29.4.5",
                 "ts-node": "^10.9.1",
                 "tsc-alias": "^1.8.17",
@@ -43,8 +39,7 @@
             },
             "peerDependencies": {
                 "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
-                "styled-components": "^5.3.0"
+                "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -79,6 +74,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
             "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.29.7",
@@ -93,6 +89,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
             "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -102,6 +99,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
@@ -132,6 +130,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -141,6 +140,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
             "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.7",
@@ -153,22 +153,11 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
-            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
             "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/compat-data": "^7.29.7",
@@ -185,6 +174,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -194,6 +184,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
             "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -203,6 +194,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
             "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/traverse": "^7.29.7",
@@ -216,6 +208,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
             "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-imports": "^7.29.7",
@@ -233,6 +226,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
             "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -242,6 +236,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
             "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -251,6 +246,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -260,6 +256,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
             "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -269,6 +266,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
             "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/template": "^7.29.7",
@@ -282,6 +280,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
             "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.7"
@@ -394,6 +393,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
             "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.29.7"
@@ -531,19 +531,11 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/runtime": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/template": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
             "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
@@ -558,6 +550,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
             "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
@@ -576,6 +569,7 @@
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
             "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.29.7",
@@ -764,33 +758,6 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
-        },
-        "node_modules/@emotion/is-prop-valid": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-            "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-            "license": "MIT",
-            "dependencies": {
-                "@emotion/memoize": "^0.9.0"
-            }
-        },
-        "node_modules/@emotion/memoize": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/stylis": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-            "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/unitless": {
-            "version": "0.7.5",
-            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-            "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-            "license": "MIT"
         },
         "node_modules/@es-joy/jsdoccomment": {
             "version": "0.78.0",
@@ -1710,6 +1677,7 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1720,6 +1688,7 @@
             "version": "2.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
             "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -1730,6 +1699,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -1739,12 +1709,14 @@
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -2028,19 +2000,6 @@
                 "chokidar": "^3.3.1"
             }
         },
-        "node_modules/@types/hoist-non-react-statics": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-            "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hoist-non-react-statics": "^3.3.0"
-            },
-            "peerDependencies": {
-                "@types/react": "*"
-            }
-        },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2123,9 +2082,9 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "19.2.15",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-            "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+            "version": "19.2.16",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+            "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2147,18 +2106,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
-            }
-        },
-        "node_modules/@types/styled-components": {
-            "version": "5.1.36",
-            "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.36.tgz",
-            "integrity": "sha512-pGMRNY5G2rNDKEv2DOiFYa7Ft1r0jrhmgBwHhOMzPTgCjO76bCot0/4uEfqj7K0Jf1KdQmDtAuaDk9EAs9foSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/hoist-non-react-statics": "*",
-                "@types/react": "*",
-                "csstype": "^3.2.2"
             }
         },
         "node_modules/@types/tough-cookie": {
@@ -2777,75 +2724,6 @@
                 "win32"
             ]
         },
-        "node_modules/@zendeskgarden/container-focusvisible": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@zendeskgarden/container-focusvisible/-/container-focusvisible-2.0.7.tgz",
-            "integrity": "sha512-qyto3EdF7eN0by0UlatqvFFaB8CTwYN/Dp2iPzBCD0bO1JVUYStdiOBTQ9TIWQ7Ktj+3PT/6rkc9/9Aphas+SA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@babel/runtime": "^7.8.4"
-            },
-            "peerDependencies": {
-                "prop-types": "^15.6.1",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@zendeskgarden/container-utilities": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-2.0.5.tgz",
-            "integrity": "sha512-z2OeNnl4xx0uK9tI3biP5o00XcISuDsfMFbpmJCUy8833gdasJyKxsOegOWPJYj5xtxZ+t4WxB3MGuytSDuaQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@babel/runtime": "^7.8.4",
-                "@reach/auto-id": "^0.18.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@zendeskgarden/container-utilities/node_modules/@reach/auto-id": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.18.0.tgz",
-            "integrity": "sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==",
-            "license": "MIT",
-            "dependencies": {
-                "@reach/utils": "0.18.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
-            }
-        },
-        "node_modules/@zendeskgarden/container-utilities/node_modules/@reach/auto-id/node_modules/@reach/utils": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.18.0.tgz",
-            "integrity": "sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "^16.8.0 || 17.x",
-                "react-dom": "^16.8.0 || 17.x"
-            }
-        },
-        "node_modules/@zendeskgarden/react-theming": {
-            "version": "8.76.9",
-            "resolved": "https://registry.npmjs.org/@zendeskgarden/react-theming/-/react-theming-8.76.9.tgz",
-            "integrity": "sha512-EYSwaFn/Dkr6ufCkFlCY5c8rGYyHVwox55tTZ+tEKVr52nLdKcVuV5Vih3Qn4+wizElJ0j1J+o5bDmKrHBKXxQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@zendeskgarden/container-focusvisible": "^2.0.3",
-                "@zendeskgarden/container-utilities": "^2.0.0",
-                "lodash.memoize": "^4.1.2",
-                "polished": "^4.3.1",
-                "prop-types": "^15.5.7"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0",
-                "styled-components": "^4.2.0 || ^5.0.0"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3265,6 +3143,7 @@
             "version": "2.10.33",
             "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
             "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -3328,6 +3207,7 @@
             "version": "4.28.2",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
             "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -3432,19 +3312,11 @@
                 "node": ">=6"
             }
         },
-        "node_modules/camelize": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-            "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001793",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
             "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -3668,6 +3540,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/copy-props": {
@@ -3704,26 +3577,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/css-color-keywords": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-            "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/css-to-react-native": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-            "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-            "license": "MIT",
-            "dependencies": {
-                "camelize": "^1.0.0",
-                "css-color-keywords": "^1.0.0",
-                "postcss-value-parser": "^4.0.2"
             }
         },
         "node_modules/css.escape": {
@@ -3772,6 +3625,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -3931,6 +3785,7 @@
             "version": "1.5.364",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
             "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -4000,6 +3855,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4748,6 +4604,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -5141,21 +4998,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/hoist-non-react-statics": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "react-is": "^16.7.0"
-            }
-        },
-        "node_modules/hoist-non-react-statics/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT"
         },
         "node_modules/homedir-polyfill": {
             "version": "1.0.3",
@@ -6472,6 +6314,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -6551,6 +6394,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -6591,6 +6435,7 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "json5": "lib/cli.js"
@@ -6699,6 +6544,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {
@@ -6712,6 +6558,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6724,6 +6571,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
@@ -6863,6 +6711,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/mute-stdout": {
@@ -6930,6 +6779,7 @@
             "version": "2.0.46",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
             "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -6977,15 +6827,6 @@
             "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/object-deep-merge": {
             "version": "2.0.1",
@@ -7317,6 +7158,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -7424,24 +7266,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/polished": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
-            "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.17.8"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/postcss-value-parser": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-            "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "license": "MIT"
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7530,23 +7354,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/prop-types": {
-            "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.4.0",
-                "object-assign": "^4.1.1",
-                "react-is": "^16.13.1"
-            }
-        },
-        "node_modules/prop-types/node_modules/react-is": {
-            "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "license": "MIT"
-        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7609,6 +7416,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -7621,6 +7429,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -7629,13 +7438,6 @@
             "peerDependencies": {
                 "react": "^18.3.1"
             }
-        },
-        "node_modules/react-is": {
-            "version": "19.2.6",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-            "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/react-is-18": {
             "name": "react-is",
@@ -7937,6 +7739,7 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -7967,12 +7770,6 @@
             "engines": {
                 "node": ">= 10.13.0"
             }
-        },
-        "node_modules/shallowequal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-            "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-            "license": "MIT"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -8346,85 +8143,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/styled-components": {
-            "version": "5.3.11",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-            "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/traverse": "^7.4.5",
-                "@emotion/is-prop-valid": "^1.1.0",
-                "@emotion/stylis": "^0.8.4",
-                "@emotion/unitless": "^0.7.4",
-                "babel-plugin-styled-components": ">= 1.12.0",
-                "css-to-react-native": "^3.0.0",
-                "hoist-non-react-statics": "^3.0.0",
-                "shallowequal": "^1.1.0",
-                "supports-color": "^5.5.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/styled-components"
-            },
-            "peerDependencies": {
-                "react": ">= 16.8.0",
-                "react-dom": ">= 16.8.0",
-                "react-is": ">= 16.8.0"
-            }
-        },
-        "node_modules/styled-components/node_modules/babel-plugin-styled-components": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.3.0.tgz",
-            "integrity": "sha512-nP/y6PbBqS/qtKROnJCgpGo8hYUzlBAVXN1QAjSBANL6vZiQXPQN7FYW/nUwoxY7nZhBEGm9T5tjL9gbzwulDw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.25.9",
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/plugin-syntax-jsx": "^7.25.9",
-                "picomatch": "^4.0.2"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0",
-                "styled-components": ">= 2"
-            }
-        },
-        "node_modules/styled-components/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/styled-components/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/styled-components/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/supports-color": {
@@ -9149,6 +8867,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
             "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -9584,6 +9303,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -35,13 +35,9 @@
         "@utils": "lib/utils",
         "@errors": "lib/errors"
     },
-    "dependencies": {
-        "@zendeskgarden/react-theming": "^8.76.9"
-    },
     "peerDependencies": {
         "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "styled-components": "^5.3.0"
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.0",
@@ -50,7 +46,7 @@
         "@types/jest": "^30.0.0",
         "@types/lodash": "^4.17.20",
         "@types/node": "^24.9.1",
-        "@types/styled-components": "^5.1.36",
+        "@types/react": "^19.2.16",
         "@typescript-eslint/parser": "^8.49.0",
         "del": "^8.0.1",
         "eslint": "^9.39.2",
@@ -65,7 +61,6 @@
         "prettier": "^3.7.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "styled-components": "^5.3.11",
         "ts-jest": "^29.4.5",
         "ts-node": "^10.9.1",
         "tsc-alias": "^1.8.17",

--- a/src/utils/convert-content-message-to-html.ts
+++ b/src/utils/convert-content-message-to-html.ts
@@ -1,6 +1,19 @@
 import { Capabilities, IAction, IContent, IContentCarousel, IContentText, IItem } from "@models/index";
-import { PALETTE } from "@zendeskgarden/react-theming";
 import { CSSProperties } from "react";
+
+/**
+ * Zendesk Garden palette values inlined to avoid a runtime dependency on
+ *
+ * @zendeskgarden/react-theming and styled-components for static color constants.
+ *
+ * Source: @zendeskgarden/react-theming v9.15.5
+ */
+const PALETTE = {
+    grey: { 200: "#e8eaec", 300: "#d8dcde", 400: "#b0b8be", 600: "#848f99" },
+    blue: { 600: "#2694d6" },
+    green: { 600: "#26a178" },
+    mint: { 600: "#16a260" }
+};
 
 /**
  * Escapes HTML special characters to prevent XSS attacks.


### PR DESCRIPTION
## Summary
- Inlined `PALETTE` color constants directly in `convert-content-message-to-html.ts` to remove the runtime dependency on `@zendeskgarden/react-theming` and `styled-components`
- Removes the `styled-components` peer dependency that was causing conflicts with consumer repos using styled-components 6.x

## Test plan
- [x] Build passes
- [x] All 162 tests pass
- [x] Lint passes