### PR TITLE
fix: resolve path aliases in compiled output

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -41,7 +41,7 @@ export function transpile() {
  * Replace all aliases by the relative path
  */
 export function convertPaths() {
-    return npmExec("tsc-alias -p tsconfig.json");
+    return npmExec("tsc-alias -p tsconfig.json --dir lib/src");
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.7.1",
+    "version": "1.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@zendesk/zaf-toolbox",
-            "version": "1.7.1",
+            "version": "1.7.3",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@eslint/js": "^9.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",


### PR DESCRIPTION
## Summary
- `tsc-alias` was not resolving `@models/`, `@services/`, `@utils/` aliases in the compiled `.js` and `.d.ts` files
- Root cause: `tsc` outputs to `lib/src/` (because `rootDir: "."`) but `tsc-alias` defaulted to scanning `lib/` — finding 0 files to transform
- Fix: add `--dir lib/src` flag so `tsc-alias` scans the correct directory

## Test plan
- [x] `npm run build` succeeds
- [x] `grep -r "@models/\|@services/\|@utils/" lib/` returns nothing (all aliases resolved)
- [x] Consumer project (`zendesk-labs-notify-app`) compiles without TS2305 errors