### PR TITLE
Allow sending notifications by BSUID for Whatsapp

### DIFF
--- a/__tests__/services/sunshine-conversation-api-service.spec.ts
+++ b/__tests__/services/sunshine-conversation-api-service.spec.ts
@@ -418,7 +418,7 @@ describe("SunshineConversationApiService", () => {
             }).rejects.toThrow(UnsupportedError);
         });
 
-        it("should throw a SyntaxError when destinationId is neither a valid E.164 phone nor a BSUID", async () => {
+        it("should throw a SyntaxError when a WhatsApp destinationId is neither E.164 nor BSUID", async () => {
             const invalidIds = ["+123", "not-a-phone", "us.123", "U.123", "US.", "12345"];
             for (const id of invalidIds) {
                 await expect(
@@ -427,7 +427,7 @@ describe("SunshineConversationApiService", () => {
             }
         });
 
-        it("should throw a SyntaxError when a BSUID is used with a non-WhatsApp integration", async () => {
+        it("should throw a SyntaxError when a Twilio destinationId is not an E.164 phone", async () => {
             const twilioIntegration: IIntegrationSuncoTwilio = {
                 id: "id",
                 status: "status",
@@ -440,9 +440,12 @@ describe("SunshineConversationApiService", () => {
                 phoneNumber: "+12345678900"
             };
 
-            await expect(
-                sunshineConversationApiService.sendNotification(twilioIntegration, bsuidSample, contentSample)
-            ).rejects.toThrow(SyntaxError);
+            const invalidIds = [bsuidSample, "+123", "not-a-phone", "12345"];
+            for (const id of invalidIds) {
+                await expect(
+                    sunshineConversationApiService.sendNotification(twilioIntegration, id, contentSample)
+                ).rejects.toThrow(SyntaxError);
+            }
         });
 
         it("should call the API with a valid E.164 phone number", async () => {

--- a/__tests__/services/sunshine-conversation-api-service.spec.ts
+++ b/__tests__/services/sunshine-conversation-api-service.spec.ts
@@ -381,6 +381,7 @@ describe("SunshineConversationApiService", () => {
 
     describe("sendNotification", () => {
         const phoneNumberSample = "+11231231234";
+        const bsuidSample = "US.13491208655302741918";
 
         const contentSample: IContent = {
             type: Capabilities.Text,
@@ -417,13 +418,34 @@ describe("SunshineConversationApiService", () => {
             }).rejects.toThrow(UnsupportedError);
         });
 
-        it("should throw an error if the phone number doesn't respect the regex", async () => {
-            await expect(async () => {
-                await sunshineConversationApiService.sendNotification(integrationSample, "+123", contentSample);
-            }).rejects.toThrow(SyntaxError);
+        it("should throw a SyntaxError when destinationId is neither a valid E.164 phone nor a BSUID", async () => {
+            const invalidIds = ["+123", "not-a-phone", "us.123", "U.123", "US.", "12345"];
+            for (const id of invalidIds) {
+                await expect(
+                    sunshineConversationApiService.sendNotification(integrationSample, id, contentSample)
+                ).rejects.toThrow(SyntaxError);
+            }
         });
 
-        it("should call the API", async () => {
+        it("should throw a SyntaxError when a BSUID is used with a non-WhatsApp integration", async () => {
+            const twilioIntegration: IIntegrationSuncoTwilio = {
+                id: "id",
+                status: "status",
+                "type": UserChannelTypes.Twilio,
+                isTalk: false,
+                accountSid: "accountSid",
+                phoneNumberSid: "phoneNumberSid",
+                messagingServiceSid: "messagingServiceSid",
+                displayName: "Twilio",
+                phoneNumber: "+12345678900"
+            };
+
+            await expect(
+                sunshineConversationApiService.sendNotification(twilioIntegration, bsuidSample, contentSample)
+            ).rejects.toThrow(SyntaxError);
+        });
+
+        it("should call the API with a valid E.164 phone number", async () => {
             client.request.mockResolvedValueOnce({
                 responseJSON: { notification: { _id: "819580915u1514141g" } }
             });
@@ -444,6 +466,46 @@ describe("SunshineConversationApiService", () => {
             const res = await sunshineConversationApiService.sendNotification(
                 integrationSample,
                 phoneNumberSample,
+                contentSample
+            );
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(res).toStrictEqual("819580915u1514141g");
+        });
+
+        it("should call the API with a valid BSUID as destinationId", async () => {
+            client.request.mockResolvedValueOnce({
+                responseJSON: { notification: { _id: "819580915u1514141g" } }
+            });
+
+            const bsuidPayload: ISendNotificationPayload = {
+                destination: {
+                    integrationId: integrationSample.id,
+                    destinationId: bsuidSample
+                },
+                author: {
+                    role: "appMaker"
+                },
+                message: contentSample,
+                messageSchema: UserChannelTypes.WhatsApp
+            };
+
+            const options = {
+                url: `https://api.smooch.io/v1.1/apps/suncoAppId/notifications`,
+                type: HttpMethod.POST,
+                contentType: "application/json",
+                data: JSON.stringify(bsuidPayload),
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                httpCompleteResponse: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            const res = await sunshineConversationApiService.sendNotification(
+                integrationSample,
+                bsuidSample,
                 contentSample
             );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.7.4",
+    "version": "1.8.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/sunshine-conversation.ts
+++ b/src/models/sunshine-conversation.ts
@@ -793,3 +793,57 @@ export interface IUpdateSuncoWebhookPayload {
     triggers?: string[];
     includeClient?: boolean;
 }
+
+/**
+ * Channel-specific user profile returned by the Sunco API (the "client" object
+ * that appears on app-user records and in webhook payloads when includeClient is true).
+ */
+export interface ISuncoClient {
+    /**
+     * The Sunco-internal client ID.
+     */
+    id: string;
+    /**
+     * The channel type (e.g. "whatsapp", "twilio").
+     */
+    type: string;
+    /**
+     * The channel-side identifier for this client.
+     *
+     * For WhatsApp clients this field is transitioning:
+     * - Legacy (pre-BSUID migration): contains the user's phone number as a numeric E.164-style string (e.g. "12025551234").
+     * - Post-migration: contains the BSUID (e.g. "US.abc123…").
+     *
+     * Both formats coexist indefinitely — legacy clients are not updated retroactively.
+     * Use BSUID_REGEX / INTERNATIONAL_PHONE_NUMBER_REGEX to detect which format you
+     * have, and read the phone number from additionalIdentifiers instead of this field.
+     */
+    externalId?: string;
+    /**
+     * Supplemental identifiers added to the client record when Meta sends a new event
+     * after the BSUID migration date (e.g. an inbound message or status update).
+     *
+     * This field is absent on client records that have not received a new event since
+     * before the migration. Never assume it is present — always handle both cases:
+     * additionalIdentifiers present but phoneNumber entry absent, and the field absent
+     * entirely.
+     */
+    additionalIdentifiers?: ISuncoClientAdditionalIdentifier[];
+}
+
+/**
+ * A single entry in the ISuncoClient.additionalIdentifiers array.
+ */
+export interface ISuncoClientAdditionalIdentifier {
+    /**
+     * The identifier type.
+     *
+     * - "phoneNumber": the user's WhatsApp phone number in E.164 format. May be absent when the user has enabled the WhatsApp username feature and the 30-day interaction window with this business number has lapsed.
+     * - "parentUserId": a BSUID representing the user's parent account in the Meta portfolio hierarchy, when applicable.
+     */
+    key: "phoneNumber" | "parentUserId";
+    /**
+     * The identifier value.
+     */
+    value: string;
+}

--- a/src/services/sunshine-conversation-api-service.ts
+++ b/src/services/sunshine-conversation-api-service.ts
@@ -203,9 +203,9 @@ export class SunshineConversationApiService {
     /**
      * Send a notification to a user using Twilio, MessageBird, or WhatsApp.
      *
-     * @param destinationId - E.164 phone number (e.g. +12025551234) for any supported channel, or a Sunco BSUID (e.g. US.13491208655302741918) for WhatsApp only.
-     * @throws SyntaxError when destinationId matches neither an E.164 phone nor a BSUID, or when a BSUID is supplied with a non-WhatsApp integration
+     * @param destinationId - E.164 phone number (e.g. +12025551234) for Twilio and MessageBird; E.164 phone or BSUID (e.g. US.13491208655302741918) for WhatsApp.
      * @throws UnsupportedError when the integration type is not supported
+     * @throws SyntaxError when destinationId does not match the format accepted by the given integration
      */
     public async sendNotification(
         integration: IIntegration,
@@ -213,26 +213,27 @@ export class SunshineConversationApiService {
         message: IContent,
         metadata?: IMetadata
     ): Promise<string> {
-        const isPhone = INTERNATIONAL_PHONE_NUMBER_REGEX.test(destinationId);
-        const isBsuid = BSUID_REGEX.test(destinationId);
-
-        if (!isPhone && !isBsuid) {
-            throw SyntaxError(
-                "destinationId must be an E.164 phone number (e.g. +12025551234) or a BSUID (e.g. US.13491208655302741918)"
-            );
-        }
-
-        if (isBsuid && integration.type !== UserChannelTypes.WhatsApp) {
-            throw SyntaxError("A BSUID destinationId is only supported for WhatsApp integrations");
-        }
-
-        // Validation of the channel used
         if (
             integration.type !== UserChannelTypes.MessageBirds &&
             integration.type !== UserChannelTypes.Twilio &&
             integration.type !== UserChannelTypes.WhatsApp
         ) {
             throw new UnsupportedError(integration.type);
+        }
+
+        const isPhone = INTERNATIONAL_PHONE_NUMBER_REGEX.test(destinationId);
+
+        if (integration.type === UserChannelTypes.WhatsApp) {
+            const isBsuid = BSUID_REGEX.test(destinationId);
+            if (!isPhone && !isBsuid) {
+                throw SyntaxError(
+                    "destinationId for WhatsApp must be an E.164 phone number (e.g. +12025551234) or a BSUID (e.g. US.13491208655302741918)"
+                );
+            }
+        } else if (!isPhone) {
+            throw SyntaxError(
+                `destinationId for ${integration.type} must be an E.164 phone number (e.g. +12025551234)`
+            );
         }
 
         const payload: ISendNotificationPayload = {

--- a/src/services/sunshine-conversation-api-service.ts
+++ b/src/services/sunshine-conversation-api-service.ts
@@ -22,7 +22,7 @@ import {
     IUpdateSuncoWebhookPayload
 } from "@models/index";
 import { buildUrlParams } from "@utils/build-url-params";
-import { INTERNATIONAL_PHONE_NUMBER_REGEX } from "@utils/regex";
+import { BSUID_REGEX, INTERNATIONAL_PHONE_NUMBER_REGEX } from "@utils/regex";
 import { IClient } from "@models/zaf-client";
 
 export class SunshineConversationApiService {
@@ -201,19 +201,29 @@ export class SunshineConversationApiService {
     }
 
     /**
-     * Send a notification to a user using Twilio or MessageBirds
+     * Send a notification to a user using Twilio, MessageBird, or WhatsApp.
      *
-     * @throws Error when the integration passed isn't supported OR if the phone number is invalid
+     * @param destinationId - E.164 phone number (e.g. +12025551234) for any supported channel, or a Sunco BSUID (e.g. US.13491208655302741918) for WhatsApp only.
+     * @throws SyntaxError when destinationId matches neither an E.164 phone nor a BSUID, or when a BSUID is supplied with a non-WhatsApp integration
+     * @throws UnsupportedError when the integration type is not supported
      */
     public async sendNotification(
         integration: IIntegration,
-        phoneNumber: string,
+        destinationId: string,
         message: IContent,
         metadata?: IMetadata
     ): Promise<string> {
-        // Validation of the phone number.
-        if (!phoneNumber.match(INTERNATIONAL_PHONE_NUMBER_REGEX)) {
-            throw SyntaxError("Phone number should follow this format: +<dial_code><number>");
+        const isPhone = INTERNATIONAL_PHONE_NUMBER_REGEX.test(destinationId);
+        const isBsuid = BSUID_REGEX.test(destinationId);
+
+        if (!isPhone && !isBsuid) {
+            throw SyntaxError(
+                "destinationId must be an E.164 phone number (e.g. +12025551234) or a BSUID (e.g. US.13491208655302741918)"
+            );
+        }
+
+        if (isBsuid && integration.type !== UserChannelTypes.WhatsApp) {
+            throw SyntaxError("A BSUID destinationId is only supported for WhatsApp integrations");
         }
 
         // Validation of the channel used
@@ -228,7 +238,7 @@ export class SunshineConversationApiService {
         const payload: ISendNotificationPayload = {
             destination: {
                 integrationId: integration.id,
-                destinationId: phoneNumber
+                destinationId
             },
             author: {
                 role: "appMaker"

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,1 +1,8 @@
-export const INTERNATIONAL_PHONE_NUMBER_REGEX = /^\+[0-9]{1,3}[0-9]{4,14}$/g;
+export const INTERNATIONAL_PHONE_NUMBER_REGEX = /^\+[0-9]{1,3}[0-9]{4,14}$/;
+
+/**
+ * Matches a Whatsapp Business System User ID (BSUID).
+ * Shape: two uppercase ASCII letters (country code), a dot, then one or more alphanumeric characters.
+ * Example: US.13491208655302741918
+ */
+export const BSUID_REGEX = /^[A-Z]{2}\.[A-Za-z0-9]+$/;


### PR DESCRIPTION
## Description

### Background

Sunco's Notifications API now auto-detects the identifier type in destinationId, accepting either an E.164 phone number or a WhatsApp BSUID (e.g. US.13491208655302741918). The previous phone-only validation blocked Relay's Step 2 retry path, which needs to re-send using a BSUID after a match_failure.

### Changes

- Added BSUID_REGEX (/^[A-Z]{2}\.[A-Za-z0-9]+$/) for validating BSUID-shaped identifiers
- Replaced the phone-only guard in sendNotification with a two-step validator
- Renamed the phoneNumber parameter to destinationId to reflect the broader contract
- Added ISuncoClient and ISuncoClientAdditionalIdentifier to expose the client object's externalId and additionalIdentifiers fields