### PR TITLE
feat: Add getUser and listClients endpoints

### DIFF
--- a/__tests__/services/sunshine-conversation-api-service.spec.ts
+++ b/__tests__/services/sunshine-conversation-api-service.spec.ts
@@ -718,4 +718,95 @@ describe("SunshineConversationApiService", () => {
             expect(client.request).toHaveBeenCalledWith(options);
         });
     });
+
+    describe("getUser", () => {
+        it("should call the API and return the user", async () => {
+            const userSample = {
+                id: "user-id-1",
+                externalId: "ext-123",
+                signedUpAt: "2024-01-01T00:00:00.000Z",
+                profile: {
+                    givenName: "John",
+                    surname: "Doe",
+                    email: "john@example.com"
+                }
+            };
+            client.request.mockResolvedValueOnce({ user: userSample });
+
+            const options = {
+                url: `https://api.smooch.io/v2/apps/suncoAppId/users/user-id-1`,
+                type: HttpMethod.GET,
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            const result = await sunshineConversationApiService.getUser("user-id-1");
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result).toBe(userSample);
+        });
+
+        it("should support fetching a user by external ID", async () => {
+            const userSample = {
+                id: "user-id-2",
+                externalId: "ext-456"
+            };
+            client.request.mockResolvedValueOnce({ user: userSample });
+
+            const options = {
+                url: `https://api.smooch.io/v2/apps/suncoAppId/users/ext-456`,
+                type: HttpMethod.GET,
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            const result = await sunshineConversationApiService.getUser("ext-456");
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result).toBe(userSample);
+        });
+    });
+
+    describe("listClients", () => {
+        const clientSample = {
+            id: "client-id-1",
+            type: "whatsapp",
+            externalId: "US.13491208655302741918",
+            additionalIdentifiers: [{ key: "phoneNumber", value: "+11231231234" }]
+        };
+
+        it("should call the API and return the clients", async () => {
+            client.request.mockResolvedValueOnce({ clients: [clientSample] });
+
+            const options = {
+                url: `https://api.smooch.io/v2/apps/suncoAppId/users/user-id-1/clients`,
+                type: HttpMethod.GET,
+                secure: appSettings.useSecure,
+                crossDomain: true,
+                headers: {
+                    Authorization: expect.any(String) as string
+                }
+            };
+
+            const result = await sunshineConversationApiService.listClients("user-id-1");
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toBe(clientSample);
+        });
+
+        it("should return an empty array when no clients are present", async () => {
+            client.request.mockResolvedValueOnce({ clients: [] });
+
+            const result = await sunshineConversationApiService.listClients("user-id-1");
+
+            expect(result).toEqual([]);
+        });
+    });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/sunshine-conversation.ts
+++ b/src/models/sunshine-conversation.ts
@@ -847,3 +847,27 @@ export interface ISuncoClientAdditionalIdentifier {
      */
     value: string;
 }
+
+export interface ISuncoUserProfile {
+    givenName?: string;
+    surname?: string;
+    email?: string;
+    avatarUrl?: string;
+    locale?: string;
+}
+
+export interface ISuncoUser {
+    id: string;
+    externalId?: string;
+    signedUpAt?: string;
+    profile?: ISuncoUserProfile;
+    metadata?: IMetadata;
+}
+
+export interface IGetUserResponse {
+    user: ISuncoUser;
+}
+
+export interface IListClientsResponse {
+    clients: ISuncoClient[];
+}

--- a/src/services/sunshine-conversation-api-service.ts
+++ b/src/services/sunshine-conversation-api-service.ts
@@ -19,7 +19,11 @@ import {
     ISendNotification,
     ICreateSuncoWebhookResponse,
     ISuncoWebhook,
-    IUpdateSuncoWebhookPayload
+    IUpdateSuncoWebhookPayload,
+    ISuncoUser,
+    IGetUserResponse,
+    ISuncoClient,
+    IListClientsResponse
 } from "@models/index";
 import { buildUrlParams } from "@utils/build-url-params";
 import { BSUID_REGEX, INTERNATIONAL_PHONE_NUMBER_REGEX } from "@utils/regex";
@@ -316,5 +320,29 @@ export class SunshineConversationApiService {
         await this.client.request(
             this.createV1Options(`/apps/${this.settings.appId}/webhooks/${webhookId}`, HttpMethod.DELETE)
         );
+    }
+
+    /**
+     * Retrieve a user by ID or external ID.
+     *
+     * @param userIdOrExternalId - The user's ID or external ID
+     */
+    public async getUser(userIdOrExternalId: string): Promise<ISuncoUser> {
+        const response = await this.client.request<IGetUserResponse>(
+            this.createV2Options(`/apps/${this.settings.appId}/users/${userIdOrExternalId}`, HttpMethod.GET)
+        );
+        return response.user;
+    }
+
+    /**
+     * List all clients for a given user.
+     *
+     * @param userIdOrExternalId - The user's ID or external ID
+     */
+    public async listClients(userIdOrExternalId: string): Promise<ISuncoClient[]> {
+        const response = await this.client.request<IListClientsResponse>(
+            this.createV2Options(`/apps/${this.settings.appId}/users/${userIdOrExternalId}/clients`, HttpMethod.GET)
+        );
+        return response.clients;
     }
 }


### PR DESCRIPTION
## Summary
- Add `getUser(userIdOrExternalId)` method to retrieve a Sunco user via the v2 API
- Add `listClients(userIdOrExternalId)` method to list all clients for a given user via the v2 API
- Add corresponding interfaces (`ISuncoUser`, `ISuncoUserProfile`, `IGetUserResponse`, `IListClientsResponse`)
- Add unit tests for both new endpoints

## Test plan
- [x] Unit tests pass (`npx jest __tests__/services/sunshine-conversation-api-service.spec.ts`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)