### PR TITLE
feat: Add UserIdentityService

### DIFF
--- a/__tests__/services/user-identity-service.spec.ts
+++ b/__tests__/services/user-identity-service.spec.ts
@@ -1,0 +1,165 @@
+import { ICreateUserIdentityBody, IZendeskUserIdentity } from "@models/index";
+import { UserIdentityService } from "@services/user-identity-service";
+
+describe("UserIdentityService", () => {
+    const client = {
+        on: jest.fn(),
+        invoke: jest.fn(),
+        get: jest.fn(),
+        set: jest.fn(),
+        request: jest.fn(),
+        metadata: jest.fn(),
+        context: jest.fn(),
+        trigger: jest.fn(),
+        instance: jest.fn(),
+        has: jest.fn(),
+        off: jest.fn()
+    };
+    const service = new UserIdentityService(client);
+    const userId = 12345;
+    const identityId = 67890;
+
+    const identitySample: IZendeskUserIdentity = {
+        id: identityId,
+        url: "https://example.zendesk.com/api/v2/users/12345/identities/67890.json",
+        user_id: userId,
+        type: "email",
+        value: "test@example.com",
+        verified: true,
+        primary: true,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+        undeliverable_count: 0,
+        deliverable_state: "deliverable"
+    };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("listIdentities", () => {
+        it("should call the API and return user identities", async () => {
+            client.request.mockResolvedValueOnce({ identities: [identitySample] });
+
+            const options = {
+                url: `/api/v2/users/${userId}/identities`,
+                type: "GET",
+                contentType: "application/json"
+            };
+            const result = await service.listIdentities(userId);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identities).toHaveLength(1);
+            expect(result.identities[0]).toBe(identitySample);
+        });
+    });
+
+    describe("showIdentity", () => {
+        it("should call the API and return a single identity", async () => {
+            client.request.mockResolvedValueOnce({ identity: identitySample });
+
+            const options = {
+                url: `/api/v2/users/${userId}/identities/${identityId}`,
+                type: "GET",
+                contentType: "application/json"
+            };
+            const result = await service.showIdentity(userId, identityId);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identity).toBe(identitySample);
+        });
+    });
+
+    describe("createIdentity", () => {
+        it("should call the API to create an identity", async () => {
+            const body: ICreateUserIdentityBody = {
+                type: "email",
+                value: "new@example.com",
+                verified: true
+            };
+            client.request.mockResolvedValueOnce({ identity: identitySample });
+
+            const options = {
+                url: `/api/v2/users/${userId}/identities`,
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify({ identity: body })
+            };
+            const result = await service.createIdentity(userId, body);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identity).toBe(identitySample);
+        });
+    });
+
+    describe("verifyIdentity", () => {
+        it("should call the API to verify an identity", async () => {
+            const verifiedIdentity = { ...identitySample, verified: true };
+            client.request.mockResolvedValueOnce({ identity: verifiedIdentity });
+
+            const options = {
+                url: `/api/v2/users/${userId}/identities/${identityId}/verify`,
+                type: "PUT",
+                contentType: "application/json"
+            };
+            const result = await service.verifyIdentity(userId, identityId);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identity.verified).toBe(true);
+        });
+    });
+
+    describe("listEndUserIdentities", () => {
+        it("should call the end_users API and return identities", async () => {
+            client.request.mockResolvedValueOnce({ identities: [identitySample] });
+
+            const options = {
+                url: `/api/v2/end_users/${userId}/identities`,
+                type: "GET",
+                contentType: "application/json"
+            };
+            const result = await service.listEndUserIdentities(userId);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identities).toHaveLength(1);
+            expect(result.identities[0]).toBe(identitySample);
+        });
+    });
+
+    describe("showEndUserIdentity", () => {
+        it("should call the end_users API and return a single identity", async () => {
+            client.request.mockResolvedValueOnce({ identity: identitySample });
+
+            const options = {
+                url: `/api/v2/end_users/${userId}/identities/${identityId}`,
+                type: "GET",
+                contentType: "application/json"
+            };
+            const result = await service.showEndUserIdentity(userId, identityId);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identity).toBe(identitySample);
+        });
+    });
+
+    describe("createEndUserIdentity", () => {
+        it("should call the end_users API to create an identity", async () => {
+            const body: ICreateUserIdentityBody = {
+                type: "email",
+                value: "enduser@example.com"
+            };
+            client.request.mockResolvedValueOnce({ identity: identitySample });
+
+            const options = {
+                url: `/api/v2/end_users/${userId}/identities`,
+                type: "POST",
+                contentType: "application/json",
+                data: JSON.stringify({ identity: body })
+            };
+            const result = await service.createEndUserIdentity(userId, body);
+
+            expect(client.request).toHaveBeenCalledWith(options);
+            expect(result.identity).toBe(identitySample);
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -10,4 +10,5 @@ export * from "@models/zendesk-user";
 export * from "@models/custom-objects";
 export * from "@models/zendesk-api";
 export * from "@models/zendesk-brands";
+export * from "@models/zendesk-user-identity";
 export * from "@models/zendesk-view";

--- a/src/models/zendesk-user-identity.ts
+++ b/src/models/zendesk-user-identity.ts
@@ -1,0 +1,37 @@
+export interface IZendeskUserIdentity {
+    id: number;
+    url: string;
+    user_id: number;
+    type:
+        | "email"
+        | "phone_number"
+        | "twitter"
+        | "facebook"
+        | "google"
+        | "agent_forwarding"
+        | "any_channel"
+        | "foreign"
+        | "sdk"
+        | "messaging";
+    value: string;
+    verified: boolean;
+    primary: boolean;
+    created_at: string;
+    updated_at: string;
+    undeliverable_count: number;
+    deliverable_state: "deliverable" | "undeliverable";
+}
+
+export interface ICreateUserIdentityBody {
+    type: string;
+    value: string;
+    verified?: boolean;
+}
+
+export interface IUserIdentityResponse {
+    identity: IZendeskUserIdentity;
+}
+
+export interface IUserIdentitiesResponse {
+    identities: IZendeskUserIdentity[];
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -2,3 +2,4 @@ export * from "@services/sunshine-conversation-api-service";
 export * from "@services/zendesk-api-service";
 export * from "@services/custom-fields-service";
 export * from "@services/custom-object-service";
+export * from "@services/user-identity-service";

--- a/src/services/user-identity-service.ts
+++ b/src/services/user-identity-service.ts
@@ -1,0 +1,66 @@
+import { ICreateUserIdentityBody, IUserIdentitiesResponse, IUserIdentityResponse } from "@models/index";
+import { IClient } from "@models/zaf-client";
+
+const CONTENT_TYPE = "application/json";
+
+export class UserIdentityService {
+    constructor(private readonly client: IClient) {}
+
+    public async listIdentities(userId: number): Promise<IUserIdentitiesResponse> {
+        return this.client.request<IUserIdentitiesResponse>({
+            url: `/api/v2/users/${userId}/identities`,
+            type: "GET",
+            contentType: CONTENT_TYPE
+        });
+    }
+
+    public async showIdentity(userId: number, identityId: number): Promise<IUserIdentityResponse> {
+        return this.client.request<IUserIdentityResponse>({
+            url: `/api/v2/users/${userId}/identities/${identityId}`,
+            type: "GET",
+            contentType: CONTENT_TYPE
+        });
+    }
+
+    public async createIdentity(userId: number, body: ICreateUserIdentityBody): Promise<IUserIdentityResponse> {
+        return this.client.request<IUserIdentityResponse>({
+            url: `/api/v2/users/${userId}/identities`,
+            type: "POST",
+            contentType: CONTENT_TYPE,
+            data: JSON.stringify({ identity: body })
+        });
+    }
+
+    public async verifyIdentity(userId: number, identityId: number): Promise<IUserIdentityResponse> {
+        return this.client.request<IUserIdentityResponse>({
+            url: `/api/v2/users/${userId}/identities/${identityId}/verify`,
+            type: "PUT",
+            contentType: CONTENT_TYPE
+        });
+    }
+
+    public async listEndUserIdentities(userId: number): Promise<IUserIdentitiesResponse> {
+        return this.client.request<IUserIdentitiesResponse>({
+            url: `/api/v2/end_users/${userId}/identities`,
+            type: "GET",
+            contentType: CONTENT_TYPE
+        });
+    }
+
+    public async showEndUserIdentity(userId: number, identityId: number): Promise<IUserIdentityResponse> {
+        return this.client.request<IUserIdentityResponse>({
+            url: `/api/v2/end_users/${userId}/identities/${identityId}`,
+            type: "GET",
+            contentType: CONTENT_TYPE
+        });
+    }
+
+    public async createEndUserIdentity(userId: number, body: ICreateUserIdentityBody): Promise<IUserIdentityResponse> {
+        return this.client.request<IUserIdentityResponse>({
+            url: `/api/v2/end_users/${userId}/identities`,
+            type: "POST",
+            contentType: CONTENT_TYPE,
+            data: JSON.stringify({ identity: body })
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new `UserIdentityService` with endpoints for managing user identities (list, show, create, verify) for both agents and end users
- Creates `IZendeskUserIdentity` model and related interfaces
- Follows the same pattern as `CustomObjectService`

## Endpoints
| Method | Endpoint |
|--------|----------|
| `listIdentities(userId)` | `GET /api/v2/users/{id}/identities` |
| `showIdentity(userId, identityId)` | `GET /api/v2/users/{id}/identities/{id}` |
| `createIdentity(userId, body)` | `POST /api/v2/users/{id}/identities` |
| `verifyIdentity(userId, identityId)` | `PUT /api/v2/users/{id}/identities/{id}/verify` |
| `listEndUserIdentities(userId)` | `GET /api/v2/end_users/{id}/identities` |
| `showEndUserIdentity(userId, identityId)` | `GET /api/v2/end_users/{id}/identities/{id}` |
| `createEndUserIdentity(userId, body)` | `POST /api/v2/end_users/{id}/identities` |

## Test plan
- [x] Unit tests covering all 7 endpoints
- [x] TypeScript compilation passes