### PR TITLE
feat: Edit Sunco client interface to fit with the integration typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/sunshine-conversation.ts
+++ b/src/models/sunshine-conversation.ts
@@ -804,9 +804,9 @@ export interface ISuncoClient {
      */
     id: string;
     /**
-     * The channel type (e.g. "whatsapp", "twilio").
+     * The channel type. Mirrors the typing used by IIntegrationBase.type.
      */
-    type: string;
+    type: UserChannelTypes;
     /**
      * The channel-side identifier for this client.
      *


### PR DESCRIPTION
## Description

Type `ISuncoClient.type` as `UserChannelTypes`

Aligns `ISuncoClient.type` with the existing convention used by `IIntegrationBase.type`. 