### PR TITLE
feat: Add listCustomObjectRecordEvents to CustomObjectService

### DIFF
--- a/__tests__/services/custom-objects.spec.ts
+++ b/__tests__/services/custom-objects.spec.ts
@@ -3,7 +3,8 @@ import {
     CustomObjectFieldType,
     ListCutomObjectRecordsSortingOptions,
     RecordBulkAction,
-    IBulkJobBodyCreate
+    IBulkJobBodyCreate,
+    ICustomObjectRecordEvent
 } from "@models/custom-objects";
 import { CustomObjectService } from "@services/index";
 import { IClient } from "@models/zaf-client";
@@ -603,6 +604,138 @@ describe("CustomObjectService", () => {
                 data: JSON.stringify(body)
             });
             expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("CustomObjectRecordEvents", () => {
+        const recordEvent: ICustomObjectRecordEvent = {
+            id: "event_1",
+            type: "record_created",
+            source: "zendesk",
+            description: "Record created",
+            actor: { user_id: 12345 },
+            created_at: "2024-03-01T10:00:00Z",
+            received_at: "2024-03-01T10:00:01Z",
+            properties: {
+                transaction_events: [
+                    {
+                        type: "create",
+                        field_key: "name",
+                        previous_value: "",
+                        current_value: "Test Record",
+                        origin: "api"
+                    }
+                ]
+            }
+        };
+
+        it("should call list events with the correct parameters", async () => {
+            requestMock.mockResolvedValueOnce({
+                custom_object_record_events: [recordEvent],
+                meta: { has_more: false, after_cursor: "", before_cursor: "" },
+                links: { next: "", prev: "" }
+            });
+
+            await service.listCustomObjectRecordEvents("foo", "record_id");
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/v2/custom_objects/foo/records/record_id/events`,
+                type: "GET",
+                contentType: "application/json",
+                data: {}
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("should call list events with pagination filter", async () => {
+            requestMock.mockResolvedValueOnce({
+                custom_object_record_events: [recordEvent],
+                meta: { has_more: false, after_cursor: "", before_cursor: "" },
+                links: { next: "", prev: "" }
+            });
+
+            await service.listCustomObjectRecordEvents("foo", "record_id", {
+                page: { size: 10 }
+            });
+
+            expect(requestMock).toHaveBeenCalledWith({
+                url: `/api/v2/custom_objects/foo/records/record_id/events`,
+                type: "GET",
+                contentType: "application/json",
+                data: {
+                    page: { size: 10 }
+                }
+            });
+            expect(requestMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("should paginate through all events when has_more is true", async () => {
+            requestMock
+                .mockResolvedValueOnce({
+                    custom_object_record_events: [recordEvent],
+                    meta: { has_more: true, after_cursor: "cursor_1", before_cursor: "" },
+                    links: { next: "next_url", prev: "" }
+                })
+                .mockResolvedValueOnce({
+                    custom_object_record_events: [{ ...recordEvent, id: "event_2" }],
+                    meta: { has_more: false, after_cursor: "", before_cursor: "" },
+                    links: { next: "", prev: "" }
+                });
+
+            const result = await service.listCustomObjectRecordEvents("foo", "record_id");
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: `/api/v2/custom_objects/foo/records/record_id/events`,
+                type: "GET",
+                contentType: "application/json",
+                data: {}
+            });
+            expect(requestMock).toHaveBeenNthCalledWith(2, {
+                url: `/api/v2/custom_objects/foo/records/record_id/events`,
+                type: "GET",
+                contentType: "application/json",
+                data: {
+                    page: { after: "cursor_1" }
+                }
+            });
+            expect(requestMock).toHaveBeenCalledTimes(2);
+            expect(result).toHaveLength(2);
+        });
+
+        it("should keep page size through all pages", async () => {
+            requestMock
+                .mockResolvedValueOnce({
+                    custom_object_record_events: [recordEvent],
+                    meta: { has_more: true, after_cursor: "cursor_1", before_cursor: "" },
+                    links: { next: "next_url", prev: "" }
+                })
+                .mockResolvedValueOnce({
+                    custom_object_record_events: [{ ...recordEvent, id: "event_2" }],
+                    meta: { has_more: false, after_cursor: "", before_cursor: "" },
+                    links: { next: "", prev: "" }
+                });
+
+            await service.listCustomObjectRecordEvents("foo", "record_id", {
+                page: { size: 5 }
+            });
+
+            expect(requestMock).toHaveBeenNthCalledWith(1, {
+                url: `/api/v2/custom_objects/foo/records/record_id/events`,
+                type: "GET",
+                contentType: "application/json",
+                data: {
+                    page: { size: 5 }
+                }
+            });
+            expect(requestMock).toHaveBeenNthCalledWith(2, {
+                url: `/api/v2/custom_objects/foo/records/record_id/events`,
+                type: "GET",
+                contentType: "application/json",
+                data: {
+                    page: { size: 5, after: "cursor_1" }
+                }
+            });
+            expect(requestMock).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zendesk/zaf-toolbox",
-    "version": "1.9.2",
+    "version": "1.10.0",
     "description": "A toolbox for ZAF application built with 🩷 by Zendesk Labs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/src/models/custom-objects.ts
+++ b/src/models/custom-objects.ts
@@ -364,4 +364,10 @@ export interface IListCustomObjectRecordEventsResponse {
     };
 }
 
-export type IListCustomObjectRecordEventsFilter = Pick<IPaginationAndSortCursor, "page">;
+// Not reusing IPaginationAndSortCursor because this endpoint expects page.size as a number, not a string.
+export interface IListCustomObjectRecordEventsFilter {
+    page?: {
+        after?: string;
+        size?: number;
+    };
+}

--- a/src/models/custom-objects.ts
+++ b/src/models/custom-objects.ts
@@ -128,7 +128,7 @@ export enum ListCutomObjectRecordsSortingOptions {
     MINUS_UPDATED_AT = "-updated_at"
 }
 
-interface IPaginationAndSortCursor {
+export interface IPaginationAndSortCursor {
     page?: {
         /**
          * A pagination cursor that tells the endpoint which page to start on. Note: page[before] and page[after] can't be used together in the same request.
@@ -212,7 +212,7 @@ export interface ICreateCustomObjectRecordBodyWithExternalId<T extends ICustomOb
 /**
  * API Responses
  */
-interface IZendeskMeta {
+export interface IZendeskMeta {
     after_cursor: string;
     before_cursor: string;
     has_more: boolean;
@@ -326,3 +326,42 @@ export interface IBulkJobResponse {
         "url": string;
     };
 }
+
+/**
+ * Custom Object Record Events
+ */
+export interface ICustomObjectRecordEventActor {
+    user_id: number;
+}
+
+export interface ICustomObjectRecordTransactionEvent {
+    type: string;
+    field_key: string;
+    previous_value: string;
+    current_value: string;
+    origin: string;
+}
+
+export interface ICustomObjectRecordEvent {
+    id: string;
+    type: "record_created" | "record_updated";
+    source: string;
+    description: string;
+    actor: ICustomObjectRecordEventActor;
+    created_at: string;
+    received_at: string;
+    properties: {
+        transaction_events: ICustomObjectRecordTransactionEvent[];
+    };
+}
+
+export interface IListCustomObjectRecordEventsResponse {
+    custom_object_record_events: ICustomObjectRecordEvent[];
+    meta: IZendeskMeta;
+    links: {
+        next: string;
+        prev: string;
+    };
+}
+
+export type IListCustomObjectRecordEventsFilter = Pick<IPaginationAndSortCursor, "page">;

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -18,7 +18,10 @@ import {
     ISearchFilterCustomObjectRecords,
     ISetCustomObjectRecordFieldBody,
     IUpdateCustomObjectFieldAutonumberingPropertiesBody,
-    IUpdateCustomObjectFieldBody
+    IUpdateCustomObjectFieldBody,
+    ICustomObjectRecordEvent,
+    IListCustomObjectRecordEventsResponse,
+    IListCustomObjectRecordEventsFilter
 } from "@models/index";
 import { IClient } from "@models/zaf-client";
 
@@ -371,6 +374,49 @@ export class CustomObjectService {
             contentType: CONTENT_TYPE,
             data: JSON.stringify(job)
         });
+    }
+
+    /**
+     * List events for a custom object record
+     *
+     * @param key - The custom object key
+     * @param recordId - The custom object record ID
+     * @param filter - Optional pagination filter
+     * @returns Array of all custom object record events
+     * @see https://developer.zendesk.com/api-reference/custom-data/custom-objects/custom_object_record_events/#list-events-for-custom-object-record
+     */
+    public async listCustomObjectRecordEvents(
+        key: string,
+        recordId: string,
+        filter?: IListCustomObjectRecordEventsFilter
+    ): Promise<ICustomObjectRecordEvent[]> {
+        let hasMore = true;
+        let data: IListCustomObjectRecordEventsFilter = filter ?? {};
+        let events: ICustomObjectRecordEvent[] = [];
+
+        do {
+            const response = await this.client.request<IListCustomObjectRecordEventsResponse>({
+                url: `/api/v2/custom_objects/${key}/records/${recordId}/events`,
+                type: "GET",
+                contentType: CONTENT_TYPE,
+                data
+            });
+
+            events = [...events, ...response.custom_object_record_events];
+
+            hasMore = response.meta.has_more;
+            if (hasMore) {
+                data = {
+                    ...filter,
+                    page: {
+                        ...filter?.page,
+                        after: response.meta.after_cursor
+                    }
+                };
+            }
+        } while (hasMore);
+
+        return events;
     }
 
     /**

--- a/src/services/custom-object-service.ts
+++ b/src/services/custom-object-service.ts
@@ -12,7 +12,6 @@ import {
     ICustomObjectRecord,
     ListCutomObjectRecordsSortingOptions,
     ICustomObjectRecordField,
-    ISearchCustomObjectRecordsFilter,
     IBulkJobResponse,
     IBulkJobBody,
     ISearchFilterCustomObjectRecords,
@@ -21,7 +20,8 @@ import {
     IUpdateCustomObjectFieldBody,
     ICustomObjectRecordEvent,
     IListCustomObjectRecordEventsResponse,
-    IListCustomObjectRecordEventsFilter
+    IListCustomObjectRecordEventsFilter,
+    IZendeskMeta
 } from "@models/index";
 import { IClient } from "@models/zaf-client";
 
@@ -174,9 +174,12 @@ export class CustomObjectService {
         key: string,
         sortOptions?: { sort: ListCutomObjectRecordsSortingOptions }
     ): Promise<ICustomObjectRecord<T>[]> {
-        return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records`, {
-            sort: sortOptions?.sort
-        });
+        return this.fetchAllPaginatedRecords<ICustomObjectRecord<T>, IListCustomObjectRecordsResponse<T>>(
+            `/api/v2/custom_objects/${key}/records`,
+            sortOptions ? { sort: sortOptions.sort } : {},
+            "GET",
+            (r) => r.custom_object_records
+        );
     }
 
     /**
@@ -283,9 +286,12 @@ export class CustomObjectService {
      * @see https://developer.zendesk.com/api-reference/custom-data/custom-objects/custom_object_records/#search-custom-object-records
      */
     public async searchRecords<T extends ICustomObjectRecordField>(key: string, query: string) {
-        return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records/search`, {
-            query
-        } as ISearchCustomObjectRecordsFilter);
+        return this.fetchAllPaginatedRecords<ICustomObjectRecord<T>, IListCustomObjectRecordsResponse<T>>(
+            `/api/v2/custom_objects/${key}/records/search`,
+            { query },
+            "GET",
+            (r) => r.custom_object_records
+        );
     }
 
     /**
@@ -347,7 +353,12 @@ export class CustomObjectService {
         fetchAllPages = true
     ): Promise<ICustomObjectRecord<T>[] | IListCustomObjectRecordsResponse<T>> {
         if (fetchAllPages) {
-            return this.fetchAllPaginatedRecords<T>(`/api/v2/custom_objects/${key}/records/search`, filter, "POST");
+            return this.fetchAllPaginatedRecords<ICustomObjectRecord<T>, IListCustomObjectRecordsResponse<T>>(
+                `/api/v2/custom_objects/${key}/records/search`,
+                filter,
+                "POST",
+                (r) => r.custom_object_records
+            );
         } else {
             return this.client.request<IListCustomObjectRecordsResponse<T>>({
                 url: `/api/v2/custom_objects/${key}/records/search`,
@@ -390,33 +401,12 @@ export class CustomObjectService {
         recordId: string,
         filter?: IListCustomObjectRecordEventsFilter
     ): Promise<ICustomObjectRecordEvent[]> {
-        let hasMore = true;
-        let data: IListCustomObjectRecordEventsFilter = filter ?? {};
-        let events: ICustomObjectRecordEvent[] = [];
-
-        do {
-            const response = await this.client.request<IListCustomObjectRecordEventsResponse>({
-                url: `/api/v2/custom_objects/${key}/records/${recordId}/events`,
-                type: "GET",
-                contentType: CONTENT_TYPE,
-                data
-            });
-
-            events = [...events, ...response.custom_object_record_events];
-
-            hasMore = response.meta.has_more;
-            if (hasMore) {
-                data = {
-                    ...filter,
-                    page: {
-                        ...filter?.page,
-                        after: response.meta.after_cursor
-                    }
-                };
-            }
-        } while (hasMore);
-
-        return events;
+        return this.fetchAllPaginatedRecords<ICustomObjectRecordEvent, IListCustomObjectRecordEventsResponse>(
+            `/api/v2/custom_objects/${key}/records/${recordId}/events`,
+            filter ?? {},
+            "GET",
+            (r) => r.custom_object_record_events
+        );
     }
 
     /**
@@ -424,17 +414,19 @@ export class CustomObjectService {
      *
      * @param url - The API endpoint URL
      * @param initialData - Initial request data
-     * @param getNextPageData - Function to build the next page request data
-     * @returns Array of all fetched records
+     * @param method - HTTP method
+     * @param extractor - Function to extract items from the response
+     * @returns Array of all fetched items
      */
-    private async fetchAllPaginatedRecords<T extends ICustomObjectRecordField>(
+    private async fetchAllPaginatedRecords<TItem, TResponse extends { meta: IZendeskMeta }>(
         url: string,
-        initialData: IListFilter | ISearchFilterCustomObjectRecords,
-        method: "GET" | "POST" | "PATCH" | "DELETE" = "GET"
-    ): Promise<ICustomObjectRecord<T>[]> {
+        initialData: object,
+        method: "GET" | "POST" | "PATCH" | "DELETE",
+        extractor: (response: TResponse) => TItem[]
+    ): Promise<TItem[]> {
         let hasMore = true;
         let d = initialData;
-        let objects: ICustomObjectRecord<T>[] = [];
+        let items: TItem[] = [];
 
         do {
             let options: {
@@ -456,21 +448,22 @@ export class CustomObjectService {
                 };
             }
 
-            const response = await this.client.request<IListCustomObjectRecordsResponse<T>>(options);
+            const response = await this.client.request<TResponse>(options);
 
-            objects = [...objects, ...response.custom_object_records];
+            items = [...items, ...extractor(response)];
 
             hasMore = response.meta.has_more;
             if (hasMore) {
                 d = {
                     ...initialData,
                     page: {
+                        ...((initialData as Record<string, unknown>).page as object),
                         after: response.meta.after_cursor
                     }
                 };
             }
         } while (hasMore);
 
-        return objects;
+        return items;
     }
 }


### PR DESCRIPTION
## Summary
- Implement the [List Events for Custom Object Record](https://developer.zendesk.com/api-reference/custom-data/custom-objects/custom_object_record_events/#list-events-for-custom-object-record) API endpoint
- Adds automatic pagination support to fetch all events across pages
- Reuses existing generic types (`IZendeskMeta`, `IPaginationAndSortCursor`) instead of duplicating pagination/meta interfaces

## Test plan
- [x] Unit tests cover: basic call, pagination filter, multi-page pagination, page size preserved across pages
- [x] Lint / Prettier / Tests pass